### PR TITLE
유저 도메인 검증 파트 피드백 반영

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,43 +1,46 @@
 plugins {
-    id 'java'
-    id 'groovy'
-    id 'org.springframework.boot' version '3.4.2'
-    id 'io.spring.dependency-management' version '1.1.7'
+	id 'java'
+	id 'groovy'
+	id 'org.springframework.boot' version '3.4.2'
+	id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.devtribe'
 version = '0.0.1-SNAPSHOT'
 
 java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
-    }
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(17)
+	}
 }
 
 configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
 }
 
 repositories {
-    mavenCentral()
+	mavenCentral()
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-hateoas'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation "com.google.guava:guava:33.4.0-jre"
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testImplementation("org.assertj:assertj-core:3.26.3")
+	implementation 'org.springframework.boot:spring-boot-starter-hateoas'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	runtimeOnly 'com.mysql:mysql-connector-j'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation("org.assertj:assertj-core:3.26.3")
 
-    testImplementation 'org.spockframework:spock-core:2.4-M4-groovy-4.0'
-    testImplementation 'org.spockframework:spock-spring:2.4-M4-groovy-4.0'
+	testImplementation 'org.spockframework:spock-core:2.4-M4-groovy-4.0'
+	testImplementation 'org.spockframework:spock-spring:2.4-M4-groovy-4.0'
+
+    implementation "com.google.guava:guava:33.4.0-jre"
 }
 
 tasks.named('test') {
-    useJUnitPlatform()
+	useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,42 +1,43 @@
 plugins {
-	id 'java'
-	id 'groovy'
-	id 'org.springframework.boot' version '3.4.2'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'groovy'
+    id 'org.springframework.boot' version '3.4.2'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.devtribe'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-hateoas'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	testImplementation("org.assertj:assertj-core:3.26.3")
+    implementation 'org.springframework.boot:spring-boot-starter-hateoas'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation "com.google.guava:guava:33.4.0-jre"
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation("org.assertj:assertj-core:3.26.3")
 
-	testImplementation 'org.spockframework:spock-core:2.4-M4-groovy-4.0'
-	testImplementation 'org.spockframework:spock-spring:2.4-M4-groovy-4.0'
+    testImplementation 'org.spockframework:spock-core:2.4-M4-groovy-4.0'
+    testImplementation 'org.spockframework:spock-spring:2.4-M4-groovy-4.0'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/devtribe/devtribe_feed_service/user/application/UserService.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/user/application/UserService.java
@@ -26,7 +26,7 @@ public class UserService {
     public User createUser(CreateUserRequest request) {
         validateCreateUserRequest(request);
 
-        User user = request.toUser();
+        User user = request.toEntity();
         return userRepository.save(user);
     }
 

--- a/src/main/java/com/devtribe/devtribe_feed_service/user/application/dtos/CreateUserRequest.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/user/application/dtos/CreateUserRequest.java
@@ -6,7 +6,7 @@ public record CreateUserRequest(String email, String password, String nickname,
                                 String biography, String companyName, String jobTitle,
                                 String githubUrl, String linkedinUrl, String blogUrl) {
 
-    public User toUser() {
+    public User toEntity() {
         return User.builder()
             .email(email)
             .password(password)

--- a/src/main/java/com/devtribe/devtribe_feed_service/user/application/validators/CreateUserRequestValidator.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/user/application/validators/CreateUserRequestValidator.java
@@ -1,5 +1,7 @@
 package com.devtribe.devtribe_feed_service.user.application.validators;
 
+import com.google.common.base.Preconditions;
+
 public class CreateUserRequestValidator {
 
     public static final Integer MAX_BIOGRAPHY_LENGTH = 100;
@@ -8,9 +10,8 @@ public class CreateUserRequestValidator {
         if (biography == null) {
             return;
         }
-        
-        if (biography.length() > MAX_BIOGRAPHY_LENGTH) {
-            throw new IllegalArgumentException("자기소개는 " + MAX_BIOGRAPHY_LENGTH + "자를 초과할 수 없습니다.");
-        }
+
+        Preconditions.checkArgument(biography.length() <= MAX_BIOGRAPHY_LENGTH,
+            "자기소개는 " + MAX_BIOGRAPHY_LENGTH + "자를 초과할 수 없습니다.");
     }
 }

--- a/src/main/java/com/devtribe/devtribe_feed_service/user/application/validators/CreateUserRequestValidator.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/user/application/validators/CreateUserRequestValidator.java
@@ -5,7 +5,11 @@ public class CreateUserRequestValidator {
     public static final Integer MAX_BIOGRAPHY_LENGTH = 100;
 
     public void validateBiography(String biography) {
-        if (biography != null && biography.length() > MAX_BIOGRAPHY_LENGTH) {
+        if (biography == null) {
+            return;
+        }
+        
+        if (biography.length() > MAX_BIOGRAPHY_LENGTH) {
             throw new IllegalArgumentException("자기소개는 " + MAX_BIOGRAPHY_LENGTH + "자를 초과할 수 없습니다.");
         }
     }

--- a/src/main/java/com/devtribe/devtribe_feed_service/user/application/validators/EmailValidator.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/user/application/validators/EmailValidator.java
@@ -1,5 +1,6 @@
 package com.devtribe.devtribe_feed_service.user.application.validators;
 
+import com.google.common.base.Preconditions;
 import java.util.regex.Pattern;
 
 public class EmailValidator {
@@ -7,50 +8,18 @@ public class EmailValidator {
     public static final Integer EMAIL_MAX_LENGTH = 320;
     public static final Integer EMAIL_LOCAL_PART_MAX_LENGTH = 64;
     public static final Integer EMAIL_DOMAIN_PART_MAX_LENGTH = 255;
-    private static final String EMAIL_REGEX =
-        "^[a-zA-Z0-9._%+-]+@" +         // 로컬 파트: 알파벳, 숫자, 점, 밑줄, 퍼센트, 플러스, 하이픈 허용
-            "(?!-)[a-zA-Z0-9-]+" +      // 도메인 시작에 하이픈 금지
-            "(?:\\.[a-zA-Z0-9-]+)*" +   // 도메인 점 구분 (연속된 점 금지)
-            "(?<!-)$";                  // 도메인 끝에 하이픈 금지
+
+    private static final String EMAIL_REGEX = "^(?=.{1," + EMAIL_MAX_LENGTH + "}$)" // 전체 길이 검증
+        + "(?=.{1," + EMAIL_LOCAL_PART_MAX_LENGTH + "}@)" // 로컬 파트 길이 검증
+        + "(?=[^@]+@[^@]{1," + EMAIL_DOMAIN_PART_MAX_LENGTH + "}$)" // 도메인 파트 길이 검증
+        + "^[a-zA-Z0-9._%+-]+@" // 로컬 파트 알파벳, 숫자, 점, 밑줄, 퍼센트, 플러스, 하이픈 허용
+        + "(?!-)[a-zA-Z0-9-]+"  // 도메인 파트 시작에 하이픈 금지
+        + "(?:\\.[a-zA-Z0-9-]+)*" // 도메인 점 구분 (연속된 점 금지)
+        + "(?<!-)$"; // 도메인 끝에 하이픈 금지
 
     public void validateEmail(String email) {
-        validateEmailLength(email);
-        validateEmailParts(email);
-        validateEmailRegex(email);
+        Preconditions.checkArgument(email != null, "이메일은 필수값입니다.");
+        Preconditions.checkArgument(!email.isEmpty(), "이메일은 빈 값일 수 없습니다.");
+        Preconditions.checkArgument(Pattern.matches(EMAIL_REGEX, email), "유효하지 않은 이메일 형식입니다.");
     }
-
-    private void validateEmailLength(String email) {
-        if (email == null || email.isEmpty()) {
-            throw new IllegalArgumentException("이메일은 비어 있거나 null일 수 없습니다.");
-        }
-
-        if (email.length() > EMAIL_MAX_LENGTH) {
-            throw new IllegalArgumentException("유효하지 않은 이메일 형식입니다.");
-        }
-    }
-
-    private void validateEmailParts(String email) {
-        String[] parts = email.split("@");
-
-        if (parts.length != 2) {
-            throw new IllegalArgumentException("유효하지 않은 이메일 형식입니다.");
-        }
-
-        String localPart = parts[0];
-        String domainPart = parts[1];
-
-        if (localPart.isEmpty() || localPart.length() > EMAIL_LOCAL_PART_MAX_LENGTH) {
-            throw new IllegalArgumentException("유효하지 않은 이메일 형식입니다.");
-        }
-        if (domainPart.isEmpty() || domainPart.length() > EMAIL_DOMAIN_PART_MAX_LENGTH) {
-            throw new IllegalArgumentException("유효하지 않은 이메일 형식입니다.");
-        }
-    }
-
-    private void validateEmailRegex(String email) {
-        if (!Pattern.matches(EMAIL_REGEX, email)) {
-            throw new IllegalArgumentException("이메일에 허용되지 않는 문자가 포함되어 있습니다.");
-        }
-    }
-
 }

--- a/src/main/java/com/devtribe/devtribe_feed_service/user/application/validators/PasswordValidator.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/user/application/validators/PasswordValidator.java
@@ -1,5 +1,6 @@
 package com.devtribe.devtribe_feed_service.user.application.validators;
 
+import com.google.common.base.Preconditions;
 import java.util.regex.Pattern;
 
 public class PasswordValidator {
@@ -14,17 +15,13 @@ public class PasswordValidator {
             + "[A-Za-z\\d@$!%*?&]+$";
 
     public void validatePassword(String password) {
-        if (password == null || password.isEmpty()) {
-            throw new IllegalArgumentException("비밀번호는 빈 값일 수 없습니다.");
-        }
-
-        if (password.length() < PASSWORD_MIN_LENGTH || password.length() > PASSWORD_MAX_LENGTH) {
-            throw new IllegalArgumentException("비밀번호의 길이가 유효하지 않습니다.");
-        }
-
-        if (!Pattern.matches(PASSWORD_REGEX, password)) {
-            throw new IllegalArgumentException("비밀번호는 대문자, 소문자, 숫자 및 특수문자를 모두 포함해야 합니다.");
-        }
+        Preconditions.checkArgument(password != null, "비밀번호는 필수 값입니다.");
+        Preconditions.checkArgument(!password.isEmpty(), "비밀번호는 비어있을 수 없습니다.");
+        Preconditions.checkArgument(password.length() >= PASSWORD_MIN_LENGTH,
+            "비밀번호의 길이가 유효하지 않습니다.");
+        Preconditions.checkArgument(password.length() <= PASSWORD_MAX_LENGTH,
+            "비밀번호의 길이가 유효하지 않습니다.");
+        Preconditions.checkArgument(Pattern.matches(PASSWORD_REGEX, password),
+            "비밀번호는 대문자, 소문자, 숫자 및 특수문자를 모두 포함해야 합니다.");
     }
-
 }

--- a/src/test/groovy/com/devtribe/devtribe_feed_service/user/application/validators/CreateUserRequestValidatorTest.groovy
+++ b/src/test/groovy/com/devtribe/devtribe_feed_service/user/application/validators/CreateUserRequestValidatorTest.groovy
@@ -2,11 +2,10 @@ package com.devtribe.devtribe_feed_service.user.application.validators
 
 import spock.lang.Specification
 
-import static com.devtribe.devtribe_feed_service.user.application.validators.CreateUserRequestValidator.MAX_BIOGRAPHY_LENGTH
-
 class CreateUserRequestValidatorTest extends Specification {
 
     def validator = new CreateUserRequestValidator()
+    static def MAX_BIOGRAPHY_LENGTH = CreateUserRequestValidator.MAX_BIOGRAPHY_LENGTH
 
     def "자기소개는 Null이거나 Empty여도 유저 정보 생성에 성공해야한다."(){
         when:
@@ -27,6 +26,7 @@ class CreateUserRequestValidatorTest extends Specification {
         validator.validateBiography(biography)
 
         then:
-        thrown(IllegalArgumentException)
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == "자기소개는 " + MAX_BIOGRAPHY_LENGTH + "자를 초과할 수 없습니다."
     }
 }

--- a/src/test/groovy/com/devtribe/devtribe_feed_service/user/application/validators/EmailValidatorTest.groovy
+++ b/src/test/groovy/com/devtribe/devtribe_feed_service/user/application/validators/EmailValidatorTest.groovy
@@ -24,10 +24,13 @@ class EmailValidatorTest extends Specification {
         validator.validateEmail(email)
 
         then:
-        thrown(IllegalArgumentException)
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == exceptedMessage
 
         where:
-        email << [null, ""]
+        email || exceptedMessage
+        null  || "이메일은 필수값입니다."
+        ""    || "이메일은 빈 값일 수 없습니다."
     }
 
     def "@가 포함되지 않은 이메일이 주어졌을 때 이메일 생성시 예외가 발생해야한다."() {
@@ -38,7 +41,8 @@ class EmailValidatorTest extends Specification {
         validator.validateEmail(email)
 
         then:
-        thrown(IllegalArgumentException)
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == "유효하지 않은 이메일 형식입니다."
     }
 
     def "@가 한 개 이상 포함된 이메일이 주어졌을 때 이메일 생성시 예외가 발생해야한다."() {
@@ -49,7 +53,8 @@ class EmailValidatorTest extends Specification {
         validator.validateEmail(email)
 
         then:
-        thrown(IllegalArgumentException)
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == "유효하지 않은 이메일 형식입니다."
     }
 
     def "로컬 파트 최대 길이가 넘는 이메일이 주어졌을 때 이메일 생성시 예외가 발생해야한다."() {
@@ -60,7 +65,8 @@ class EmailValidatorTest extends Specification {
         validator.validateEmail(email)
 
         then:
-        thrown(IllegalArgumentException)
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == "유효하지 않은 이메일 형식입니다."
     }
 
     def "도메인 파트 최대 길이가 넘는 이메일이 주어졌을 때 이메일 생성시 예외가 발생해야한다."() {
@@ -71,7 +77,8 @@ class EmailValidatorTest extends Specification {
         validator.validateEmail(email)
 
         then:
-        thrown(IllegalArgumentException)
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == "유효하지 않은 이메일 형식입니다."
     }
 
     def "로컬 파트가 빈 문자열인 이메일이 주어졌을 때 이메일 생성시 예외가 발생해야한다."() {
@@ -82,7 +89,8 @@ class EmailValidatorTest extends Specification {
         validator.validateEmail(email)
 
         then:
-        thrown(IllegalArgumentException)
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == "유효하지 않은 이메일 형식입니다."
     }
 
     def "도메인파트가 빈 문자열인 이메일이 주어졌을 때 이메일 생성시 예외가 발생해야한다."() {
@@ -93,7 +101,8 @@ class EmailValidatorTest extends Specification {
         validator.validateEmail(email)
 
         then:
-        thrown(IllegalArgumentException)
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == "유효하지 않은 이메일 형식입니다."
     }
 
     def "로컬 파트와 도메인 파트 모두 빈 문자열인 이메일이 주어졌을 때 이메일 생성시 예외가 발생해야한다."() {
@@ -104,7 +113,8 @@ class EmailValidatorTest extends Specification {
         validator.validateEmail(email)
 
         then:
-        thrown(IllegalArgumentException)
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == "유효하지 않은 이메일 형식입니다."
     }
 
     def "로컬 파트에 허용되지 않은 특수 문자 포함한 이메일이 주어졌을 때 이메일 생성시 예외가 발생해야한다."() {
@@ -112,7 +122,8 @@ class EmailValidatorTest extends Specification {
         validator.validateEmail(email)
 
         then:
-        thrown(IllegalArgumentException)
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == "유효하지 않은 이메일 형식입니다."
 
         where:
         email << ["user,name@example.com", "(username)@example.com", "user:name@example.com",
@@ -125,7 +136,8 @@ class EmailValidatorTest extends Specification {
         validator.validateEmail(email)
 
         then:
-        thrown(IllegalArgumentException)
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == "유효하지 않은 이메일 형식입니다."
 
         where:
         email << ["username@exam_ple.com", "user@example\$name.com", "user@example!name.com",
@@ -137,13 +149,14 @@ class EmailValidatorTest extends Specification {
         validator.validateEmail(email)
 
         then:
-        thrown(IllegalArgumentException)
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == "유효하지 않은 이메일 형식입니다."
 
         where:
         email << ["username@-example", "username@example-"]
     }
 
-    def "도메인 파트에 연속된 점이 포함된 이메일이 주어졌을 때 이메일 생성시 예외가 발생해야한다."(){
+    def "도메인 파트에 연속된 점이 포함된 이메일이 주어졌을 때 이메일 생성시 예외가 발생해야한다."() {
         given:
         String email = "username@example..com"
 
@@ -151,6 +164,7 @@ class EmailValidatorTest extends Specification {
         validator.validateEmail(email)
 
         then:
-        thrown(IllegalArgumentException)
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == "유효하지 않은 이메일 형식입니다."
     }
 }

--- a/src/test/groovy/com/devtribe/devtribe_feed_service/user/application/validators/PasswordValidatorTest.groovy
+++ b/src/test/groovy/com/devtribe/devtribe_feed_service/user/application/validators/PasswordValidatorTest.groovy
@@ -22,10 +22,14 @@ class PasswordValidatorTest extends Specification {
         validator.validatePassword(password)
 
         then:
-        thrown(IllegalArgumentException)
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == expectedMessage
 
         where:
-        password << [null, ""]
+        password || expectedMessage
+        null     || "비밀번호는 필수 값입니다."
+        ""       || "비밀번호는 비어있을 수 없습니다."
+
     }
 
     def "비밀번호 길이를 만족하지 않을 경우 예외가 발생해야 한다."() {
@@ -34,12 +38,10 @@ class PasswordValidatorTest extends Specification {
 
         then:
         def e = thrown(IllegalArgumentException)
-        e.message == expectedMessage
+        e.message == "비밀번호의 길이가 유효하지 않습니다."
 
         where:
-        password                                                      || expectedMessage
-        "Aa1!aa"                                                      || "비밀번호의 길이가 유효하지 않습니다."
-        "A1!" + "a".repeat(PasswordValidator.PASSWORD_MAX_LENGTH - 2) || "비밀번호의 길이가 유효하지 않습니다."
+        password << ["Aa1!aa", "A1!" + "a".repeat(PasswordValidator.PASSWORD_MAX_LENGTH - 2)]
     }
 
     def "대문자/소문자/숫자/특수문가 없는 경우 비밀번호 생성 시 예외가 발생해야 한다."() {
@@ -48,13 +50,9 @@ class PasswordValidatorTest extends Specification {
 
         then:
         def e = thrown(IllegalArgumentException)
-        e.message == exceptedMessage
+        e.message == "비밀번호는 대문자, 소문자, 숫자 및 특수문자를 모두 포함해야 합니다."
 
         where:
-        password    || exceptedMessage
-        "abcd1234!" || "비밀번호는 대문자, 소문자, 숫자 및 특수문자를 모두 포함해야 합니다."
-        "ABCD1234!" || "비밀번호는 대문자, 소문자, 숫자 및 특수문자를 모두 포함해야 합니다."
-        "ABCDEFGH!" || "비밀번호는 대문자, 소문자, 숫자 및 특수문자를 모두 포함해야 합니다."
-        "ABCD1234"  || "비밀번호는 대문자, 소문자, 숫자 및 특수문자를 모두 포함해야 합니다."
+        password << ["abcd1234!", "ABCD1234!", "ABCDEFGH!", "ABCD1234"]
     }
 }


### PR DESCRIPTION
## 1. 연관 이슈 
close: #8 
related: https://github.com/f-lab-edu/dev-tribe-feed-service/pull/3#pullrequestreview-2603847828

## 2. 작업 내용 

안녕하세요 @f-lab-moony 멘토님! 지난 User 도메인 검증과 관련된 피드백 내용들을 금번 PR에 반영했습니다. 세부적인 내용들은 다음과 같습니다.

- `guava` 라이브러리 추가 
- 유효성 검사 로직 시 `Preconditions` 사용 변경
- 가독성을 위한 메서드명, 코드 수정 
  - Dto의 엔티티 변환 메서드명 변경(`toUser`에서 `toEntity`로)
  - 조건문 단순화(얼리 리턴)
  - 이메일 검증 로직 일부 정규식에 병합
- 테스트 코드 개선
  - 예외 메시지 검증 코드 추가

## 3. 느낀점
> 추천해주신 `Preconditions` 사용 후기

- `Preconditions` 를 사용하고나서 유효성 검증하는 코드가 훨씬 더 깔끔해지고, 인자로 받는 `expreesion`이 더 직관적으로 다가와서 좋았습니다. 사용하는 방법도 그리 어렵지 않아서 쉽게 적용해볼 수 있었습니다. 감사합니다 :) 
- 멘토님 께서는 `guava` 라이브러리에서 `Preconditions`이외에 추가로 자주 혹은 즐겨쓰시는 기능들이 있으신가요??

> 코드 가독성 

- 얼리리턴을 사용한 코드와 사용하지 않은 코드의 diff를 살펴보면서 코드를 읽는 흐름이 빨라진 것을 느낄 수 있어서 좋았습니다. 