### PR TITLE
피드 정렬 조회 서비스 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,11 @@ repositories {
 	mavenCentral()
 }
 
+// gradle build 스크립트에서 사용하는 추가 속성 정의
+ext {
+    set('queryDslVersion', "5.0.0")
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-hateoas'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -39,6 +44,13 @@ dependencies {
 	testImplementation 'org.spockframework:spock-spring:2.4-M4-groovy-4.0'
 
     implementation "com.google.guava:guava:33.4.0-jre"
+
+    // Querydsl
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/devtribe/devtribe_feed_service/DevtribeFeedServiceApplication.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/DevtribeFeedServiceApplication.java
@@ -2,10 +2,8 @@ package com.devtribe.devtribe_feed_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class DevtribeFeedServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/devtribe/devtribe_feed_service/global/common/CursorMetadata.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/global/common/CursorMetadata.java
@@ -1,6 +1,0 @@
-package com.devtribe.devtribe_feed_service.global.common;
-
-
-public record CursorMetadata(Long nextCursor, Long totalCount, boolean hasNextPage) {
-
-}

--- a/src/main/java/com/devtribe/devtribe_feed_service/global/common/CursorMetadata.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/global/common/CursorMetadata.java
@@ -1,0 +1,6 @@
+package com.devtribe.devtribe_feed_service.global.common;
+
+
+public record CursorMetadata(Long nextCursor, Long totalCount, boolean hasNextPage) {
+
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/global/common/CursorPagination.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/global/common/CursorPagination.java
@@ -1,6 +1,9 @@
 package com.devtribe.devtribe_feed_service.global.common;
 
-public record CursorPagination(Long lastFetchedId, int pageSize) {
+public record CursorPagination(
+    Long cursorId,
+    Integer pageSize
+) {
 
     private static final int DEFAULT_PAG_SIZE = 10;
     private static final int MAX_PAG_SIZE = 30;

--- a/src/main/java/com/devtribe/devtribe_feed_service/global/common/CursorPagination.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/global/common/CursorPagination.java
@@ -1,0 +1,16 @@
+package com.devtribe.devtribe_feed_service.global.common;
+
+public record CursorPagination(Long lastFetchedId, int pageSize) {
+
+    private static final int DEFAULT_PAG_SIZE = 10;
+    private static final int MAX_PAG_SIZE = 30;
+    private static final int MIN_PAG_SIZE = 1;
+
+    public static CursorPagination defaultCursorPagination() {
+        return new CursorPagination(null, DEFAULT_PAG_SIZE);
+    }
+
+    public boolean isPageSizeInRange() {
+        return this.pageSize <= MAX_PAG_SIZE && this.pageSize >= MIN_PAG_SIZE;
+    }
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/global/common/CursorPagination.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/global/common/CursorPagination.java
@@ -9,8 +9,9 @@ public record CursorPagination(
     private static final int MAX_PAG_SIZE = 30;
     private static final int MIN_PAG_SIZE = 1;
 
-    public static CursorPagination defaultCursorPagination() {
-        return new CursorPagination(null, DEFAULT_PAG_SIZE);
+    public CursorPagination(Long cursorId, Integer pageSize) {
+        this.cursorId = cursorId;
+        this.pageSize = pageSize == null ? DEFAULT_PAG_SIZE : pageSize;
     }
 
     public boolean isPageSizeInRange() {

--- a/src/main/java/com/devtribe/devtribe_feed_service/global/common/PageResponse.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/global/common/PageResponse.java
@@ -1,0 +1,7 @@
+package com.devtribe.devtribe_feed_service.global.common;
+
+import java.util.List;
+
+public record PageResponse<T>(List<T> data, Long nextCursor, Long totalCount, boolean hasNextPage) {
+
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/global/config/JpaAuditingConfiguration.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/global/config/JpaAuditingConfiguration.java
@@ -1,0 +1,10 @@
+package com.devtribe.devtribe_feed_service.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/global/config/QuerydslConfiguration.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/global/config/QuerydslConfiguration.java
@@ -1,0 +1,22 @@
+package com.devtribe.devtribe_feed_service.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class QuerydslConfiguration {
+
+    private final EntityManager entityManager;
+
+    public QuerydslConfiguration(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/global/error/ErrorResponse.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/global/error/ErrorResponse.java
@@ -1,0 +1,5 @@
+package com.devtribe.devtribe_feed_service.global.error;
+
+public record ErrorResponse(String errorMessage) {
+
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/global/error/GlobalExceptionHandler.java
@@ -3,14 +3,20 @@ package com.devtribe.devtribe_feed_service.global.error;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
-    protected ResponseEntity<?> handleIllegalArgumentException(IllegalArgumentException exception) {
+    protected ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException exception) {
         ErrorResponse response = new ErrorResponse(exception.getMessage());
         return ResponseEntity.badRequest().body(response);
     }
 
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleEnumMismatch(MethodArgumentTypeMismatchException exception) {
+        ErrorResponse response = new ErrorResponse("올바르지 않은 요청 값입니다.");
+        return ResponseEntity.badRequest().body(response);
+    }
 }

--- a/src/main/java/com/devtribe/devtribe_feed_service/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.devtribe.devtribe_feed_service.global.error;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    protected ResponseEntity<?> handleIllegalArgumentException(IllegalArgumentException exception) {
+        ErrorResponse response = new ErrorResponse(exception.getMessage());
+        return ResponseEntity.badRequest().body(response);
+    }
+
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/api/FeedController.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/api/FeedController.java
@@ -20,11 +20,10 @@ public class FeedController {
     }
 
     @GetMapping
-    public ResponseEntity<GetFeedResponse> getFeedListBySortOption(
+    public GetFeedResponse getFeedListBySortOption(
         @RequestParam(required = false) CursorPagination cursorPagination,
         @RequestParam(required = false) String sort
     ) {
-        GetFeedResponse response = feedService.getFeedListBySortOption(cursorPagination, sort);
-        return ResponseEntity.ok(response);
+        return feedService.getFeedListBySortOption(cursorPagination, sort);
     }
 }

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/api/FeedController.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/api/FeedController.java
@@ -22,9 +22,10 @@ public class FeedController {
 
     @GetMapping
     public PageResponse<PostResponse> getFeedListBySortOption(
-        @RequestParam(required = false) CursorPagination cursorPagination,
+        @RequestParam(value = "cursorId", required = false) Long cursorId,
+        @RequestParam(value = "size", required = false) Integer pageSize,
         @RequestParam(defaultValue = "BY_NEWEST") FeedSortOption sort
     ) {
-        return feedService.getFeedListBySortOption(cursorPagination, sort);
+        return feedService.getFeedListBySortOption(new CursorPagination(cursorId, pageSize), sort);
     }
 }

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/api/FeedController.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/api/FeedController.java
@@ -1,9 +1,9 @@
 package com.devtribe.devtribe_feed_service.post.api;
 
 import com.devtribe.devtribe_feed_service.global.common.CursorPagination;
+import com.devtribe.devtribe_feed_service.global.common.PageResponse;
 import com.devtribe.devtribe_feed_service.post.application.FeedService;
-import com.devtribe.devtribe_feed_service.post.application.dtos.GetFeedResponse;
-import org.springframework.http.ResponseEntity;
+import com.devtribe.devtribe_feed_service.post.application.dtos.PostResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -20,7 +20,7 @@ public class FeedController {
     }
 
     @GetMapping
-    public GetFeedResponse getFeedListBySortOption(
+    public PageResponse<PostResponse> getFeedListBySortOption(
         @RequestParam(required = false) CursorPagination cursorPagination,
         @RequestParam(required = false) String sort
     ) {

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/api/FeedController.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/api/FeedController.java
@@ -1,0 +1,30 @@
+package com.devtribe.devtribe_feed_service.post.api;
+
+import com.devtribe.devtribe_feed_service.global.common.CursorPagination;
+import com.devtribe.devtribe_feed_service.post.application.FeedService;
+import com.devtribe.devtribe_feed_service.post.application.dtos.GetFeedResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/feeds")
+public class FeedController {
+
+    private final FeedService feedService;
+
+    public FeedController(FeedService feedService) {
+        this.feedService = feedService;
+    }
+
+    @GetMapping
+    public ResponseEntity<GetFeedResponse> getFeedListBySortOption(
+        @RequestParam(required = false) CursorPagination cursorPagination,
+        @RequestParam(required = false) String sort
+    ) {
+        GetFeedResponse response = feedService.getFeedListBySortOption(cursorPagination, sort);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/api/FeedController.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/api/FeedController.java
@@ -4,6 +4,7 @@ import com.devtribe.devtribe_feed_service.global.common.CursorPagination;
 import com.devtribe.devtribe_feed_service.global.common.PageResponse;
 import com.devtribe.devtribe_feed_service.post.application.FeedService;
 import com.devtribe.devtribe_feed_service.post.application.dtos.PostResponse;
+import com.devtribe.devtribe_feed_service.post.domain.FeedSortOption;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -22,7 +23,7 @@ public class FeedController {
     @GetMapping
     public PageResponse<PostResponse> getFeedListBySortOption(
         @RequestParam(required = false) CursorPagination cursorPagination,
-        @RequestParam(required = false) String sort
+        @RequestParam(defaultValue = "BY_NEWEST") FeedSortOption sort
     ) {
         return feedService.getFeedListBySortOption(cursorPagination, sort);
     }

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/api/PostController.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/api/PostController.java
@@ -1,6 +1,16 @@
 package com.devtribe.devtribe_feed_service.post.api;
 
 import com.devtribe.devtribe_feed_service.post.application.PostService;
+import com.devtribe.devtribe_feed_service.post.application.dtos.CreatePostRequest;
+import com.devtribe.devtribe_feed_service.post.application.dtos.CreatePostResponse;
+import com.devtribe.devtribe_feed_service.post.application.dtos.UpdatePostRequest;
+import com.devtribe.devtribe_feed_service.post.application.dtos.UpdatePostResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,4 +24,24 @@ public class PostController {
         this.postService = postService;
     }
 
+    @PostMapping
+    public ResponseEntity<CreatePostResponse> createPost(@RequestBody CreatePostRequest request) {
+        CreatePostResponse responseBody = postService.createPost(request);
+        return ResponseEntity.ok(responseBody);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<UpdatePostResponse> updatePost(
+        @PathVariable("id") Long id,
+        @RequestBody UpdatePostRequest request
+    ) {
+        UpdatePostResponse responseBody = postService.updatePost(id, request);
+        return ResponseEntity.ok(responseBody);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletePost(@PathVariable("id") Long id) {
+        postService.deletePost(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/application/FeedService.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/application/FeedService.java
@@ -27,10 +27,6 @@ public class FeedService {
         getFeedRequestValidator.validateCursorPagination(cursorPagination);
         getFeedRequestValidator.validateSortOption(sort);
 
-        if (cursorPagination == null) {
-            cursorPagination = CursorPagination.defaultCursorPagination();
-        }
-
         PageResponse<Post> postPageResponse = feedRepository.findAllBySortOption(cursorPagination, sort);
 
         return new PageResponse<>(

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/application/FeedService.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/application/FeedService.java
@@ -1,0 +1,58 @@
+package com.devtribe.devtribe_feed_service.post.application;
+
+import com.devtribe.devtribe_feed_service.global.common.CursorMetadata;
+import com.devtribe.devtribe_feed_service.global.common.CursorPagination;
+import com.devtribe.devtribe_feed_service.global.common.PageResponse;
+import com.devtribe.devtribe_feed_service.post.application.dtos.GetFeedResponse;
+import com.devtribe.devtribe_feed_service.post.application.dtos.PostResponse;
+import com.devtribe.devtribe_feed_service.post.application.interfaces.FeedRepository;
+import com.devtribe.devtribe_feed_service.post.application.validators.GetFeedRequestValidator;
+import com.devtribe.devtribe_feed_service.post.domain.FeedSortOption;
+import com.devtribe.devtribe_feed_service.post.domain.Post;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class FeedService {
+
+    private final FeedRepository feedRepository;
+    private final GetFeedRequestValidator getFeedRequestValidator;
+
+    public FeedService(FeedRepository feedRepository, GetFeedRequestValidator getFeedRequestValidator) {
+        this.feedRepository = feedRepository;
+        this.getFeedRequestValidator = getFeedRequestValidator;
+    }
+
+    @Transactional(readOnly = true)
+    public GetFeedResponse getFeedListBySortOption(CursorPagination cursorPagination, String sort) {
+        getFeedRequestValidator.validateCursorPagination(cursorPagination);
+        getFeedRequestValidator.validateSortOption(sort);
+
+        if (cursorPagination == null) {
+            cursorPagination = CursorPagination.defaultCursorPagination();
+        }
+
+        PageResponse<Post> postPageResponse = feedRepository.findAllBySortOption(
+            cursorPagination,
+            FeedSortOption.fromValue(sort)
+        );
+
+        return new GetFeedResponse(
+            convertToPostResponses(postPageResponse.data()),
+            createCursorMetadata(postPageResponse)
+        );
+    }
+
+    private List<PostResponse> convertToPostResponses(List<Post> posts) {
+        return posts.stream().map(PostResponse::from).toList();
+    }
+
+    private CursorMetadata createCursorMetadata(PageResponse<Post> postPageResponse) {
+        return new CursorMetadata(
+            postPageResponse.nextCursor(),
+            postPageResponse.totalCount(),
+            postPageResponse.hasNextPage()
+        );
+    }
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/application/FeedService.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/application/FeedService.java
@@ -1,9 +1,7 @@
 package com.devtribe.devtribe_feed_service.post.application;
 
-import com.devtribe.devtribe_feed_service.global.common.CursorMetadata;
 import com.devtribe.devtribe_feed_service.global.common.CursorPagination;
 import com.devtribe.devtribe_feed_service.global.common.PageResponse;
-import com.devtribe.devtribe_feed_service.post.application.dtos.GetFeedResponse;
 import com.devtribe.devtribe_feed_service.post.application.dtos.PostResponse;
 import com.devtribe.devtribe_feed_service.post.application.interfaces.FeedRepository;
 import com.devtribe.devtribe_feed_service.post.application.validators.GetFeedRequestValidator;
@@ -25,7 +23,7 @@ public class FeedService {
     }
 
     @Transactional(readOnly = true)
-    public GetFeedResponse getFeedListBySortOption(CursorPagination cursorPagination, String sort) {
+    public PageResponse<PostResponse> getFeedListBySortOption(CursorPagination cursorPagination, String sort) {
         getFeedRequestValidator.validateCursorPagination(cursorPagination);
         getFeedRequestValidator.validateSortOption(sort);
 
@@ -38,21 +36,15 @@ public class FeedService {
             FeedSortOption.fromValue(sort)
         );
 
-        return new GetFeedResponse(
+        return new PageResponse<>(
             convertToPostResponses(postPageResponse.data()),
-            createCursorMetadata(postPageResponse)
+            postPageResponse.nextCursor(),
+            postPageResponse.totalCount(),
+            postPageResponse.hasNextPage()
         );
     }
 
     private List<PostResponse> convertToPostResponses(List<Post> posts) {
         return posts.stream().map(PostResponse::from).toList();
-    }
-
-    private CursorMetadata createCursorMetadata(PageResponse<Post> postPageResponse) {
-        return new CursorMetadata(
-            postPageResponse.nextCursor(),
-            postPageResponse.totalCount(),
-            postPageResponse.hasNextPage()
-        );
     }
 }

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/application/FeedService.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/application/FeedService.java
@@ -23,7 +23,7 @@ public class FeedService {
     }
 
     @Transactional(readOnly = true)
-    public PageResponse<PostResponse> getFeedListBySortOption(CursorPagination cursorPagination, String sort) {
+    public PageResponse<PostResponse> getFeedListBySortOption(CursorPagination cursorPagination, FeedSortOption sort) {
         getFeedRequestValidator.validateCursorPagination(cursorPagination);
         getFeedRequestValidator.validateSortOption(sort);
 
@@ -31,10 +31,7 @@ public class FeedService {
             cursorPagination = CursorPagination.defaultCursorPagination();
         }
 
-        PageResponse<Post> postPageResponse = feedRepository.findAllBySortOption(
-            cursorPagination,
-            FeedSortOption.fromValue(sort)
-        );
+        PageResponse<Post> postPageResponse = feedRepository.findAllBySortOption(cursorPagination, sort);
 
         return new PageResponse<>(
             convertToPostResponses(postPageResponse.data()),

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/application/PostService.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/application/PostService.java
@@ -1,7 +1,9 @@
 package com.devtribe.devtribe_feed_service.post.application;
 
 import com.devtribe.devtribe_feed_service.post.application.dtos.CreatePostRequest;
+import com.devtribe.devtribe_feed_service.post.application.dtos.CreatePostResponse;
 import com.devtribe.devtribe_feed_service.post.application.dtos.UpdatePostRequest;
+import com.devtribe.devtribe_feed_service.post.application.dtos.UpdatePostResponse;
 import com.devtribe.devtribe_feed_service.post.application.interfaces.PostRepository;
 import com.devtribe.devtribe_feed_service.post.application.validators.PostRequestValidator;
 import com.devtribe.devtribe_feed_service.post.domain.Post;
@@ -33,16 +35,17 @@ public class PostService {
     }
 
     @Transactional
-    public Post createPost(CreatePostRequest request) {
+    public CreatePostResponse createPost(CreatePostRequest request) {
         postRequestValidator.validateTitle(request.title());
         postRequestValidator.validateBody(request.content());
 
         User findUser = userService.getUser(request.authorId());
-        return postRepository.save(request.toEntity(findUser));
+        Post savedPost = postRepository.save(request.toEntity(findUser));
+        return new CreatePostResponse(savedPost.getId());
     }
 
     @Transactional
-    public Post updatePost(Long postId, UpdatePostRequest request) {
+    public UpdatePostResponse updatePost(Long postId, UpdatePostRequest request) {
         postRequestValidator.validateTitle(request.title());
         postRequestValidator.validateBody(request.content());
 
@@ -51,7 +54,7 @@ public class PostService {
         validateAuthor(findPost, requestAuthor);
 
         findPost.updatePostDetail(request);
-        return findPost;
+        return UpdatePostResponse.from(findPost);
     }
 
     @Transactional

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/application/dtos/CreatePostResponse.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/application/dtos/CreatePostResponse.java
@@ -1,0 +1,5 @@
+package com.devtribe.devtribe_feed_service.post.application.dtos;
+
+public record CreatePostResponse(Long id) {
+
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/application/dtos/GetFeedResponse.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/application/dtos/GetFeedResponse.java
@@ -1,8 +1,0 @@
-package com.devtribe.devtribe_feed_service.post.application.dtos;
-
-import com.devtribe.devtribe_feed_service.global.common.CursorMetadata;
-import java.util.List;
-
-public record GetFeedResponse(List<PostResponse> data, CursorMetadata cursorMetaData) {
-
-}

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/application/dtos/GetFeedResponse.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/application/dtos/GetFeedResponse.java
@@ -1,0 +1,8 @@
+package com.devtribe.devtribe_feed_service.post.application.dtos;
+
+import com.devtribe.devtribe_feed_service.global.common.CursorMetadata;
+import java.util.List;
+
+public record GetFeedResponse(List<PostResponse> data, CursorMetadata cursorMetaData) {
+
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/application/dtos/UpdatePostResponse.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/application/dtos/UpdatePostResponse.java
@@ -1,0 +1,17 @@
+package com.devtribe.devtribe_feed_service.post.application.dtos;
+
+import com.devtribe.devtribe_feed_service.post.domain.Post;
+import com.devtribe.devtribe_feed_service.post.domain.Publication;
+
+public record UpdatePostResponse(String title, String content, String thumbnail,
+                                 Publication publication) {
+
+    public static UpdatePostResponse from(Post post) {
+        return new UpdatePostResponse(
+            post.getTitle(),
+            post.getContent(),
+            post.getThumbnail(),
+            post.getPublication()
+        );
+    }
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/application/interfaces/FeedRepository.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/application/interfaces/FeedRepository.java
@@ -1,0 +1,13 @@
+package com.devtribe.devtribe_feed_service.post.application.interfaces;
+
+import com.devtribe.devtribe_feed_service.global.common.CursorPagination;
+import com.devtribe.devtribe_feed_service.global.common.PageResponse;
+import com.devtribe.devtribe_feed_service.post.domain.FeedSortOption;
+import com.devtribe.devtribe_feed_service.post.domain.Post;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FeedRepository {
+
+    PageResponse<Post> findAllBySortOption(CursorPagination cursorPagination, FeedSortOption feedSortOption);
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/application/validators/GetFeedRequestValidator.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/application/validators/GetFeedRequestValidator.java
@@ -1,0 +1,25 @@
+package com.devtribe.devtribe_feed_service.post.application.validators;
+
+import com.devtribe.devtribe_feed_service.global.common.CursorPagination;
+import com.devtribe.devtribe_feed_service.post.domain.FeedSortOption;
+import com.google.common.base.Preconditions;
+import java.util.Arrays;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GetFeedRequestValidator {
+
+    public void validateCursorPagination(CursorPagination cursorPagination) {
+        if (cursorPagination == null) {
+            return;
+        }
+
+        Preconditions.checkArgument(!cursorPagination.isPageSizeInRange(), "유효하지 않은 요청 값입니다.");
+    }
+
+    public void validateSortOption(String sort) {
+        Arrays.stream(FeedSortOption.values())
+            .filter(feedSortOption -> feedSortOption.valueEquals(sort))
+            .findAny().orElseThrow(() -> new IllegalArgumentException("올바른 정렬 값이 아닙니다."));
+    }
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/application/validators/GetFeedRequestValidator.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/application/validators/GetFeedRequestValidator.java
@@ -10,16 +10,15 @@ import org.springframework.stereotype.Component;
 public class GetFeedRequestValidator {
 
     public void validateCursorPagination(CursorPagination cursorPagination) {
-        if (cursorPagination == null) {
-            return;
-        }
-
-        Preconditions.checkArgument(!cursorPagination.isPageSizeInRange(), "유효하지 않은 요청 값입니다.");
+        Preconditions.checkArgument(cursorPagination != null, "유효하지 않은 요청 값입니다.");
+        Preconditions.checkArgument(cursorPagination.pageSize() != null, "페이지 수는 null일 수 없습니다.");
+        Preconditions.checkArgument(cursorPagination.isPageSizeInRange(), "요청한 페이지 수의 범위가 올바르지 않습니다.");
     }
 
-    public void validateSortOption(String sort) {
+    public void validateSortOption(FeedSortOption sort) {
+        Preconditions.checkArgument(sort != null, "유효하지 않은 요청 값입니다.");
         Arrays.stream(FeedSortOption.values())
-            .filter(feedSortOption -> feedSortOption.valueEquals(sort))
+            .filter(feedSortOption -> feedSortOption.equals(sort))
             .findAny().orElseThrow(() -> new IllegalArgumentException("올바른 정렬 값이 아닙니다."));
     }
 }

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/domain/FeedSortOption.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/domain/FeedSortOption.java
@@ -1,0 +1,68 @@
+package com.devtribe.devtribe_feed_service.post.domain;
+
+import static com.devtribe.devtribe_feed_service.post.domain.QPost.post;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
+public enum FeedSortOption {
+    BY_NEWEST("최신순", "latest", post.createdAt.desc(),
+        (lastPost) -> post.createdAt.lt(lastPost.getCreatedAt())
+            .or(post.createdAt.eq(lastPost.getCreatedAt())
+                .and(post.id.lt(lastPost.getId()))
+            )),
+    BY_OLDEST("오래된순", "oldest", post.createdAt.asc(),
+        (lastPost) -> post.createdAt.gt(lastPost.getCreatedAt())
+            .or(post.createdAt.eq(lastPost.getCreatedAt())
+                .and(post.id.gt(lastPost.getId()))
+            )),
+    BY_UPVOTE("추천순", "upvote", post.upvoteCount.desc(),
+        (lastPost) -> post.upvoteCount.lt(lastPost.getUpvoteCount())
+            .or(
+                post.upvoteCount.eq(lastPost.getUpvoteCount())
+                    .and(post.id.lt(lastPost.getId()))
+            )),
+    BY_DOWNVOTE("비추천순", "downvote", post.downvoteCount.desc(),
+        (lastPost) -> post.downvoteCount.lt(lastPost.getDownvoteCount())
+            .or(
+                post.downvoteCount.eq(lastPost.getDownvoteCount())
+                    .and(post.id.lt(lastPost.getId()))
+            ));
+
+    private final String title;
+    private final String value;
+    private final OrderSpecifier<?> orderSpecifier;
+    private final QueryCondition queryCondition;
+
+    FeedSortOption(String title, String value, OrderSpecifier<?> orderSpecifier,
+        QueryCondition queryCondition) {
+        this.title = title;
+        this.value = value;
+        this.orderSpecifier = orderSpecifier;
+        this.queryCondition = queryCondition;
+    }
+
+    public static FeedSortOption fromValue(String value) {
+        return Arrays.stream(FeedSortOption.values())
+            .filter(feedSortOption -> feedSortOption.valueEquals(value))
+            .findAny()
+            .orElse(BY_NEWEST);
+    }
+
+    public boolean valueEquals(String value) {
+        return this.value.equals(value);
+    }
+
+    public BooleanExpression getQueryCondition(Post lastPost) {
+        return queryCondition.getQuery(lastPost);
+    }
+
+    interface QueryCondition {
+
+        BooleanExpression getQuery(Post lastPost);
+    }
+
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/domain/FeedSortOption.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/domain/FeedSortOption.java
@@ -1,48 +1,21 @@
 package com.devtribe.devtribe_feed_service.post.domain;
 
-import static com.devtribe.devtribe_feed_service.post.domain.QPost.post;
-
-import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import java.util.Arrays;
 import lombok.Getter;
 
 @Getter
 public enum FeedSortOption {
-    BY_NEWEST("최신순", "latest", post.createdAt.desc(),
-        (lastPost) -> post.createdAt.lt(lastPost.getCreatedAt())
-            .or(post.createdAt.eq(lastPost.getCreatedAt())
-                .and(post.id.lt(lastPost.getId()))
-            )),
-    BY_OLDEST("오래된순", "oldest", post.createdAt.asc(),
-        (lastPost) -> post.createdAt.gt(lastPost.getCreatedAt())
-            .or(post.createdAt.eq(lastPost.getCreatedAt())
-                .and(post.id.gt(lastPost.getId()))
-            )),
-    BY_UPVOTE("추천순", "upvote", post.upvoteCount.desc(),
-        (lastPost) -> post.upvoteCount.lt(lastPost.getUpvoteCount())
-            .or(
-                post.upvoteCount.eq(lastPost.getUpvoteCount())
-                    .and(post.id.lt(lastPost.getId()))
-            )),
-    BY_DOWNVOTE("비추천순", "downvote", post.downvoteCount.desc(),
-        (lastPost) -> post.downvoteCount.lt(lastPost.getDownvoteCount())
-            .or(
-                post.downvoteCount.eq(lastPost.getDownvoteCount())
-                    .and(post.id.lt(lastPost.getId()))
-            ));
+    BY_NEWEST("최신순", "latest"),
+    BY_OLDEST("오래된순", "oldest"),
+    BY_UPVOTE("추천순", "upvote"),
+    BY_DOWNVOTE("비추천순", "downvote");
 
     private final String title;
     private final String value;
-    private final OrderSpecifier<?> orderSpecifier;
-    private final QueryCondition queryCondition;
 
-    FeedSortOption(String title, String value, OrderSpecifier<?> orderSpecifier,
-        QueryCondition queryCondition) {
+    FeedSortOption(String title, String value) {
         this.title = title;
         this.value = value;
-        this.orderSpecifier = orderSpecifier;
-        this.queryCondition = queryCondition;
     }
 
     public static FeedSortOption fromValue(String value) {
@@ -52,17 +25,7 @@ public enum FeedSortOption {
             .orElse(BY_NEWEST);
     }
 
-    public boolean valueEquals(String value) {
+    private boolean valueEquals(String value) {
         return this.value.equals(value);
     }
-
-    public BooleanExpression getQueryCondition(Post lastPost) {
-        return queryCondition.getQuery(lastPost);
-    }
-
-    interface QueryCondition {
-
-        BooleanExpression getQuery(Post lastPost);
-    }
-
 }

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/repository/FeedRepositoryImpl.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/repository/FeedRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.devtribe.devtribe_feed_service.post.repository;
+
+import com.devtribe.devtribe_feed_service.global.common.CursorPagination;
+import com.devtribe.devtribe_feed_service.global.common.PageResponse;
+import com.devtribe.devtribe_feed_service.post.application.interfaces.FeedRepository;
+import com.devtribe.devtribe_feed_service.post.domain.FeedSortOption;
+import com.devtribe.devtribe_feed_service.post.domain.Post;
+import com.devtribe.devtribe_feed_service.post.repository.query.QueryFeedBySortOption;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class FeedRepositoryImpl implements FeedRepository {
+
+    private final QueryFeedBySortOption queryFeedBySortOption;
+
+    public FeedRepositoryImpl(QueryFeedBySortOption queryFeedBySortOption) {
+        this.queryFeedBySortOption = queryFeedBySortOption;
+    }
+
+    @Override
+    public PageResponse<Post> findAllBySortOption(CursorPagination cursorPagination, FeedSortOption feedSortOption) {
+        return this.queryFeedBySortOption.findAllBySortOption(cursorPagination, feedSortOption);
+    }
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/repository/FeedRepositoryImpl.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/repository/FeedRepositoryImpl.java
@@ -18,7 +18,13 @@ public class FeedRepositoryImpl implements FeedRepository {
     }
 
     @Override
-    public PageResponse<Post> findAllBySortOption(CursorPagination cursorPagination, FeedSortOption feedSortOption) {
-        return this.queryFeedBySortOption.findAllBySortOption(cursorPagination, feedSortOption);
+    public PageResponse<Post> findAllBySortOption(
+        CursorPagination cursorPagination,
+        FeedSortOption feedSortOption
+    ) {
+        return this.queryFeedBySortOption.findAllBySortOption(
+            cursorPagination.cursorId(),
+            cursorPagination.pageSize(),
+            feedSortOption);
     }
 }

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/repository/query/QueryFeedBySortOption.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/repository/query/QueryFeedBySortOption.java
@@ -38,11 +38,7 @@ public class QueryFeedBySortOption {
             .limit(pageSize + 1)
             .fetch();
 
-        boolean hasMore = queryResult.size() > pageSize;
-        List<Post> data = getPostList(queryResult, pageSize, hasMore);
-        Long nextCursor = getNextCursor(queryResult, pageSize, hasMore);
-
-        return new PageResponse<>(data, nextCursor, (long) data.size(), hasMore);
+        return getPageResponse(queryResult, pageSize);
     }
 
     private Post getCursorPost(Long cursorId) {
@@ -52,6 +48,14 @@ public class QueryFeedBySortOption {
         return queryFactory.selectFrom(post)
             .where(post.id.eq(cursorId))
             .fetchOne();
+    }
+
+    private PageResponse<Post> getPageResponse(List<Post> queryResult, Integer pageSize) {
+        boolean hasMore = queryResult.size() > pageSize;
+        List<Post> data = getPostList(queryResult, pageSize, hasMore);
+        Long nextCursor = getNextCursor(queryResult, pageSize, hasMore);
+
+        return new PageResponse<>(data, nextCursor, (long) data.size(), hasMore);
     }
 
     private List<Post> getPostList(List<Post> queryResult, int pageSize, boolean hasMore) {

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/repository/query/QueryFeedBySortOption.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/repository/query/QueryFeedBySortOption.java
@@ -51,24 +51,15 @@ public class QueryFeedBySortOption {
     }
 
     private PageResponse<Post> getPageResponse(List<Post> queryResult, Integer pageSize) {
+        if (queryResult.isEmpty()) {
+            return new PageResponse<>(List.of(), null, 0L, false);
+        }
+
         boolean hasMore = queryResult.size() > pageSize;
-        List<Post> data = getPostList(queryResult, pageSize, hasMore);
-        Long nextCursor = getNextCursor(queryResult, pageSize, hasMore);
+        List<Post> data = queryResult.subList(0, Math.min(queryResult.size(), pageSize));
+        Long nextCursor = hasMore ? queryResult.get(pageSize).getId() : null;
 
         return new PageResponse<>(data, nextCursor, (long) data.size(), hasMore);
     }
 
-    private List<Post> getPostList(List<Post> queryResult, int pageSize, boolean hasMore) {
-        if (!hasMore) {
-            return queryResult;
-        }
-        return queryResult.subList(0, pageSize);
-    }
-
-    private Long getNextCursor(List<Post> queryResult, int pageSize, boolean hasMore) {
-        if (!hasMore) {
-            return null;
-        }
-        return queryResult.get(pageSize).getId();
-    }
 }

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/repository/query/QueryFeedBySortOption.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/repository/query/QueryFeedBySortOption.java
@@ -2,7 +2,6 @@ package com.devtribe.devtribe_feed_service.post.repository.query;
 
 import static com.devtribe.devtribe_feed_service.post.domain.QPost.post;
 
-import com.devtribe.devtribe_feed_service.global.common.CursorPagination;
 import com.devtribe.devtribe_feed_service.global.common.PageResponse;
 import com.devtribe.devtribe_feed_service.post.domain.FeedSortOption;
 import com.devtribe.devtribe_feed_service.post.domain.Post;
@@ -23,11 +22,12 @@ public class QueryFeedBySortOption {
     }
 
     public PageResponse<Post> findAllBySortOption(
-        CursorPagination cursorPagination,
+        Long cursorId,
+        Integer pageSize,
         FeedSortOption feedSortOption
     ) {
         SortQuery sortQuery = sortQueryFactory.getSortQuery(feedSortOption);
-        Post cursorPost = getCursorPost(cursorPagination.cursorId());
+        Post cursorPost = getCursorPost(cursorId);
         BooleanExpression whereCondition =
             cursorPost != null ? sortQuery.getWhereCondition(cursorPost) : null;
 
@@ -35,10 +35,9 @@ public class QueryFeedBySortOption {
             .selectFrom(post)
             .where(whereCondition)
             .orderBy(sortQuery.getOrderBy())
-            .limit(cursorPagination.pageSize() + 1)
+            .limit(pageSize + 1)
             .fetch();
 
-        int pageSize = cursorPagination.pageSize();
         boolean hasMore = queryResult.size() > pageSize;
         List<Post> data = getPostList(queryResult, pageSize, hasMore);
         Long nextCursor = getNextCursor(queryResult, pageSize, hasMore);

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/repository/query/QueryFeedBySortOption.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/repository/query/QueryFeedBySortOption.java
@@ -1,0 +1,71 @@
+package com.devtribe.devtribe_feed_service.post.repository.query;
+
+import static com.devtribe.devtribe_feed_service.post.domain.QPost.post;
+
+import com.devtribe.devtribe_feed_service.global.common.CursorPagination;
+import com.devtribe.devtribe_feed_service.global.common.PageResponse;
+import com.devtribe.devtribe_feed_service.post.domain.FeedSortOption;
+import com.devtribe.devtribe_feed_service.post.domain.Post;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class QueryFeedBySortOption {
+
+    private final JPAQueryFactory queryFactory;
+
+    public QueryFeedBySortOption(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    public PageResponse<Post> findAllBySortOption(CursorPagination cursorPagination,
+        FeedSortOption feedSortOption) {
+        int pageSize = cursorPagination.pageSize();
+
+        List<Post> queryResult = queryFactory
+            .selectFrom(post)
+            .where(cursorCondition(cursorPagination, feedSortOption))
+            .orderBy(feedSortOption.getOrderSpecifier())
+            .limit(cursorPagination.pageSize() + 1)
+            .fetch();
+
+        boolean hasMore = queryResult.size() > pageSize;
+        List<Post> data = getPostList(queryResult, pageSize, hasMore);
+        Long nextCursor = getNextCursor(queryResult, pageSize, hasMore);
+
+        return new PageResponse<>(data, nextCursor, (long) queryResult.size(), hasMore);
+    }
+
+    private BooleanExpression cursorCondition(CursorPagination cursorPagination,
+        FeedSortOption feedSortOption) {
+        if (cursorPagination.lastFetchedId() == null) {
+            return null;
+        }
+
+        Post lastPost = queryFactory.selectFrom(post)
+            .where(post.id.eq(cursorPagination.lastFetchedId()))
+            .fetchOne();
+
+        if (lastPost == null) {
+            return null;
+        }
+
+        return feedSortOption.getQueryCondition(lastPost);
+    }
+
+    private List<Post> getPostList(List<Post> queryResult, int pageSize, boolean hasMore) {
+        if (!hasMore) {
+            return queryResult;
+        }
+        return queryResult.subList(0, pageSize);
+    }
+
+    private Long getNextCursor(List<Post> queryResult, int pageSize, boolean hasMore) {
+        if (!hasMore) {
+            return null;
+        }
+        return queryResult.get(pageSize).getId();
+    }
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/repository/query/QueryFeedBySortOption.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/repository/query/QueryFeedBySortOption.java
@@ -40,12 +40,12 @@ public class QueryFeedBySortOption {
 
     private BooleanExpression cursorCondition(CursorPagination cursorPagination,
         FeedSortOption feedSortOption) {
-        if (cursorPagination.lastFetchedId() == null) {
+        if (cursorPagination.cursorId() == null) {
             return null;
         }
 
         Post lastPost = queryFactory.selectFrom(post)
-            .where(post.id.eq(cursorPagination.lastFetchedId()))
+            .where(post.id.eq(cursorPagination.cursorId()))
             .fetchOne();
 
         if (lastPost == null) {

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/repository/query/SortQuery.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/repository/query/SortQuery.java
@@ -1,0 +1,14 @@
+package com.devtribe.devtribe_feed_service.post.repository.query;
+
+import com.devtribe.devtribe_feed_service.post.domain.Post;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import org.springframework.stereotype.Component;
+
+@Component
+public interface SortQuery {
+
+    BooleanExpression getWhereCondition(Post cursorPost);
+
+    OrderSpecifier<?> getOrderBy();
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/repository/query/SortQueryFactory.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/repository/query/SortQueryFactory.java
@@ -1,0 +1,25 @@
+package com.devtribe.devtribe_feed_service.post.repository.query;
+
+import com.devtribe.devtribe_feed_service.post.domain.FeedSortOption;
+import com.devtribe.devtribe_feed_service.post.repository.query.sortquery.DownvoteSort;
+import com.devtribe.devtribe_feed_service.post.repository.query.sortquery.NewestSort;
+import com.devtribe.devtribe_feed_service.post.repository.query.sortquery.OldestSort;
+import com.devtribe.devtribe_feed_service.post.repository.query.sortquery.UpvoteSort;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SortQueryFactory {
+
+    private final Map<FeedSortOption, SortQuery> sortQueryStrategyMap = Map.of(
+        FeedSortOption.BY_NEWEST, new NewestSort(),
+        FeedSortOption.BY_OLDEST, new OldestSort(),
+        FeedSortOption.BY_UPVOTE, new UpvoteSort(),
+        FeedSortOption.BY_DOWNVOTE, new DownvoteSort()
+    );
+
+    public SortQuery getSortQuery(FeedSortOption feedSortOption) {
+        return sortQueryStrategyMap.get(feedSortOption);
+    }
+
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/repository/query/sortquery/DownvoteSort.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/repository/query/sortquery/DownvoteSort.java
@@ -1,0 +1,25 @@
+package com.devtribe.devtribe_feed_service.post.repository.query.sortquery;
+
+import static com.devtribe.devtribe_feed_service.post.domain.QPost.post;
+
+import com.devtribe.devtribe_feed_service.post.domain.Post;
+import com.devtribe.devtribe_feed_service.post.repository.query.SortQuery;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+public class DownvoteSort implements SortQuery {
+
+    @Override
+    public BooleanExpression getWhereCondition(Post cursorPost) {
+        BooleanExpression lessThanDownvote = post.downvoteCount.lt(cursorPost.getDownvoteCount());
+        BooleanExpression ifSameDownvoteThanLessOrEqualId = post.downvoteCount.eq(cursorPost.getDownvoteCount())
+            .and(post.id.loe(cursorPost.getId()));
+
+        return lessThanDownvote.or(ifSameDownvoteThanLessOrEqualId);
+    }
+
+    @Override
+    public OrderSpecifier<?> getOrderBy() {
+        return post.downvoteCount.desc();
+    }
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/repository/query/sortquery/NewestSort.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/repository/query/sortquery/NewestSort.java
@@ -1,0 +1,25 @@
+package com.devtribe.devtribe_feed_service.post.repository.query.sortquery;
+
+import static com.devtribe.devtribe_feed_service.post.domain.QPost.post;
+
+import com.devtribe.devtribe_feed_service.post.domain.Post;
+import com.devtribe.devtribe_feed_service.post.repository.query.SortQuery;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+public class NewestSort implements SortQuery {
+
+    @Override
+    public BooleanExpression getWhereCondition(Post cursorPost) {
+        BooleanExpression lessThanCreated = post.createdAt.lt(cursorPost.getCreatedAt());
+        BooleanExpression ifSameCreatedThanLessOrEqualId = post.createdAt.eq(cursorPost.getCreatedAt())
+            .and(post.id.loe(cursorPost.getId()));
+
+        return lessThanCreated.or(ifSameCreatedThanLessOrEqualId);
+    }
+
+    @Override
+    public OrderSpecifier<?> getOrderBy() {
+        return post.createdAt.desc();
+    }
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/repository/query/sortquery/OldestSort.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/repository/query/sortquery/OldestSort.java
@@ -1,0 +1,25 @@
+package com.devtribe.devtribe_feed_service.post.repository.query.sortquery;
+
+import static com.devtribe.devtribe_feed_service.post.domain.QPost.post;
+
+import com.devtribe.devtribe_feed_service.post.domain.Post;
+import com.devtribe.devtribe_feed_service.post.repository.query.SortQuery;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+public class OldestSort implements SortQuery {
+
+    @Override
+    public BooleanExpression getWhereCondition(Post cursorPost) {
+        BooleanExpression greaterThanCreatedAt = post.createdAt.gt(cursorPost.getCreatedAt());
+        BooleanExpression ifSameCreatedThanGreaterOrEqualId = post.createdAt.eq(cursorPost.getCreatedAt())
+            .and(post.id.goe(cursorPost.getId()));
+
+        return greaterThanCreatedAt.or(ifSameCreatedThanGreaterOrEqualId);
+    }
+
+    @Override
+    public OrderSpecifier<?> getOrderBy() {
+        return post.createdAt.asc();
+    }
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/repository/query/sortquery/UpvoteSort.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/repository/query/sortquery/UpvoteSort.java
@@ -1,0 +1,25 @@
+package com.devtribe.devtribe_feed_service.post.repository.query.sortquery;
+
+import static com.devtribe.devtribe_feed_service.post.domain.QPost.post;
+
+import com.devtribe.devtribe_feed_service.post.domain.Post;
+import com.devtribe.devtribe_feed_service.post.repository.query.SortQuery;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+public class UpvoteSort implements SortQuery {
+
+    @Override
+    public BooleanExpression getWhereCondition(Post cursorPost) {
+        BooleanExpression lessThenUpvote = post.upvoteCount.lt(cursorPost.getUpvoteCount());
+        BooleanExpression ifSameUpvoteThenLessOrEqualId = post.upvoteCount.eq(cursorPost.getUpvoteCount())
+            .and(post.id.loe(cursorPost.getId()));
+
+        return lessThenUpvote.or(ifSameUpvoteThenLessOrEqualId);
+    }
+
+    @Override
+    public OrderSpecifier<?> getOrderBy() {
+        return post.upvoteCount.desc();
+    }
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/user/application/UserService.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/user/application/UserService.java
@@ -26,9 +26,10 @@ public class UserService {
         this.createUserRequestValidator = createUserRequestValidator;
     }
 
+    @Transactional(readOnly = true)
     public User getUser(Long userId) {
-        // TODO: userId를 갖는 User를 반환.
-        return null;
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
     }
 
     @Transactional

--- a/src/main/java/com/devtribe/devtribe_feed_service/user/application/interfaces/UserRepository.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/user/application/interfaces/UserRepository.java
@@ -1,6 +1,7 @@
 package com.devtribe.devtribe_feed_service.user.application.interfaces;
 
 import com.devtribe.devtribe_feed_service.user.domain.User;
+import java.util.Optional;
 
 public interface UserRepository {
 
@@ -9,4 +10,6 @@ public interface UserRepository {
     boolean isEmailRegistered(String email);
 
     boolean isNicknameUsed(String nickname);
+
+    Optional<User> findById(long id);
 }

--- a/src/main/java/com/devtribe/devtribe_feed_service/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/user/repository/UserRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.devtribe.devtribe_feed_service.user.repository;
 import com.devtribe.devtribe_feed_service.user.application.interfaces.UserRepository;
 import com.devtribe.devtribe_feed_service.user.domain.User;
 import com.devtribe.devtribe_feed_service.user.repository.jpa.JpaUserRepository;
+import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -27,5 +28,10 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public boolean isNicknameUsed(String nickname) {
         return jpaUserRepository.existsByNickname(nickname);
+    }
+
+    @Override
+    public Optional<User> findById(long id) {
+        return jpaUserRepository.findById(id);
     }
 }

--- a/src/test/groovy/com/devtribe/devtribe_feed_service/post/api/FeedControllerTest.groovy
+++ b/src/test/groovy/com/devtribe/devtribe_feed_service/post/api/FeedControllerTest.groovy
@@ -1,0 +1,88 @@
+package com.devtribe.devtribe_feed_service.post.api
+
+import com.devtribe.devtribe_feed_service.global.common.CursorMetadata
+import com.devtribe.devtribe_feed_service.post.application.FeedService
+import com.devtribe.devtribe_feed_service.post.application.dtos.GetFeedResponse
+import com.devtribe.devtribe_feed_service.post.application.dtos.PostResponse
+import com.devtribe.devtribe_feed_service.test.fixtures.PostResponseFixture
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.spockframework.spring.SpringBean
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.util.LinkedMultiValueMap
+import spock.lang.Specification
+import spock.lang.Title
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+
+@Title(value = "피드 조회 컨트롤러 테스트")
+@WebMvcTest(FeedController.class)
+class FeedControllerTest extends Specification {
+
+    @Autowired
+    MockMvc mockMvc
+
+    @Autowired
+    ObjectMapper objectMapper
+
+    @SpringBean
+    FeedService feedService = Mock()
+
+    def "피드 정렬 조회 성공 - 200 status와 피드 리스트 반환"() {
+        given:
+        def requestParams = new LinkedMultiValueMap<String, String>()
+        requestParams.add("cursor", "1")
+        requestParams.add("pageSize", "10")
+        requestParams.add("sort", "latest")
+        def response = new GetFeedResponse(
+                PostResponseFixture.createLatestPostResponse(10),
+                new CursorMetadata(null, 10, false))
+        feedService.getFeedListBySortOption(_, _) >> response
+
+        when:
+        def result = mockMvc.perform(get("/api/v1/feeds")
+                .contentType(MediaType.APPLICATION_JSON)
+                .params(requestParams))
+                .andReturn()
+
+        then:
+        def content = result.response.getContentAsString()
+        def responseBody = objectMapper.readTree(content)
+
+        result.response.status == HttpStatus.OK.value()
+        (responseBody.get("data") as List<PostResponse>).size() == 10
+        responseBody.get("cursorMetaData").get("nextCursor").isNull()
+        responseBody.get("cursorMetaData").get("totalCount").asInt() == 10
+        !responseBody.get("cursorMetaData").get("hasNextPage")
+    }
+
+    def "피드 정렬 조회 실패 - 올바르지 않은 파라미터, 400 status와 에러메시지 반환"() {
+        given:
+        def requestParams = new LinkedMultiValueMap<String, String>()
+        requestParams.add("cursor", "1")
+        requestParams.add("pageSize", pageSize)
+        requestParams.add("sort", sort)
+        feedService.getFeedListBySortOption(_, _) >> { throw new IllegalArgumentException(exceptionMessage) }
+
+        when:
+        def result = mockMvc.perform(get("/api/v1/feeds")
+                .contentType(MediaType.APPLICATION_JSON)
+                .params(requestParams))
+                .andReturn()
+
+        then:
+        def content = result.response.getContentAsString()
+        def responseBody = objectMapper.readTree(content)
+
+        result.response.status == HttpStatus.BAD_REQUEST.value()
+        responseBody.get("errorMessage").asText() == exceptionMessage
+
+        where:
+        pageSize | sort          || exceptionMessage
+        "10"     | "invalidSort" || "올바른 정렬 값이 아닙니다."
+        "999999" | "oldest"      || "유효하지 않은 요청 값입니다."
+    }
+}

--- a/src/test/groovy/com/devtribe/devtribe_feed_service/post/api/PostControllerTest.groovy
+++ b/src/test/groovy/com/devtribe/devtribe_feed_service/post/api/PostControllerTest.groovy
@@ -1,0 +1,187 @@
+package com.devtribe.devtribe_feed_service.post.api
+
+import com.devtribe.devtribe_feed_service.post.application.PostService
+import com.devtribe.devtribe_feed_service.post.application.dtos.CreatePostRequest
+import com.devtribe.devtribe_feed_service.post.application.dtos.CreatePostResponse
+import com.devtribe.devtribe_feed_service.post.application.dtos.UpdatePostRequest
+import com.devtribe.devtribe_feed_service.post.application.dtos.UpdatePostResponse
+import com.devtribe.devtribe_feed_service.post.domain.Publication
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.spockframework.spring.SpringBean
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import spock.lang.Specification
+import spock.lang.Title
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+
+@Title(value = "게시글 컨트롤러 테스트")
+@WebMvcTest(PostController.class)
+class PostControllerTest extends Specification {
+
+    @Autowired
+    MockMvc mockMvc
+    @Autowired
+    ObjectMapper objectMapper
+    @SpringBean
+    PostService postService = Mock(PostService)
+
+    def "게시물 생성 성공 - 200 status와 게시물 id를 반환"() {
+        given:
+        def createRequest = new CreatePostRequest(
+                "새로운 Post 제목",
+                "새로운 내용",
+                1L,
+                "https://example.com/thumbnail.jpg"
+        )
+        def response = new CreatePostResponse(1L)
+        postService.createPost(createRequest) >> response
+
+        when:
+        def result = mockMvc.perform(
+                post("/api/v1/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createRequest)))
+                .andDo(print())
+                .andReturn()
+
+        then:
+        def content = result.response.getContentAsString()
+        final JsonNode responseBody = objectMapper.readTree(content)
+
+        result.response.status == HttpStatus.OK.value()
+        responseBody.get("id").asLong() == response.id()
+    }
+
+    def "게시물 생성 실패 - 존재하지 않는 유저, 400 status와 예외메시지를 반환한다."() {
+        given:
+        def createRequest = new CreatePostRequest(
+                "새로운 Post 제목",
+                "새로운 내용",
+                999L,
+                "https://example.com/thumbnail.jpg"
+        )
+        postService.createPost(createRequest) >> { throw new IllegalArgumentException("존재하지 않는 유저입니다.") }
+
+        when:
+        def result = mockMvc.perform(
+                post("/api/v1/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createRequest)))
+                .andDo(print())
+                .andReturn()
+
+        then:
+        result.response.status == HttpStatus.BAD_REQUEST.value()
+    }
+
+    def "게시물 수정 성공 - 200 status와 수정 결과를 반환한다."() {
+        given:
+        def postId = 1L
+        def updateRequest = new UpdatePostRequest(
+                1L,
+                "변경 제목",
+                "변경 본문",
+                "https://example.com/change-thumbnail.jpg",
+                Publication.PRIVATE
+        )
+        def updateResponse = new UpdatePostResponse(
+                "변경 제목",
+                "변경 본문",
+                "https://example.com/change-thumbnail.jpg",
+                Publication.PRIVATE
+        )
+        postService.updatePost(postId, updateRequest) >> updateResponse
+
+        when:
+        def result = mockMvc.perform(
+                put("/api/v1/posts/{id}", postId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andDo(print())
+                .andReturn()
+
+        then:
+        def content = result.response.getContentAsString()
+        final JsonNode responseBody = objectMapper.readTree(content)
+
+        result.response.status == HttpStatus.OK.value()
+        responseBody.get("title").asText() == updateRequest.title()
+        responseBody.get("content").asText() == updateRequest.content()
+        responseBody.get("thumbnail").asText() == updateRequest.thumbnail()
+        responseBody.get("publication").asText() == updateRequest.publication().name()
+
+    }
+
+    def "게시물 수정 실패 - 유효하지 않은 요청, 400 status와 예외메시지를 반환한다."() {
+        given:
+        def updateRequest = new UpdatePostRequest(
+                userId,
+                "변경 제목",
+                "변경 본문",
+                "https://example.com/change-thumbnail.jpg",
+                Publication.PRIVATE
+        )
+        postService.updatePost(postId, updateRequest) >> { throw new IllegalArgumentException(exceptionMessage) }
+
+        when:
+        def result = mockMvc.perform(
+                put("/api/v1/posts/{id}", postId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andDo(print())
+                .andReturn()
+
+        then:
+        def content = result.response.getContentAsString()
+        final JsonNode responseBody = objectMapper.readTree(content)
+
+        result.response.status == exceptStatusCode
+        responseBody.get("errorMessage").asText() == exceptionMessage
+
+        where:
+        postId | userId | exceptStatusCode               | exceptionMessage
+        999L   | 1L     | HttpStatus.BAD_REQUEST.value() | "존재하지 않는 게시물입니다."
+        1L     | 999L   | HttpStatus.BAD_REQUEST.value() | "존재하지 않는 유저입니다."
+        1L     | 2L     | HttpStatus.BAD_REQUEST.value() | "게시물 작성자가 아닙니다."
+    }
+
+    def "게시물 삭제 성공 - 204 status 반환"() {
+        given:
+        def postId = 1L
+
+        when:
+        def result = mockMvc.perform(
+                delete("/api/v1/posts/{id}", postId))
+                .andDo(print())
+                .andReturn()
+
+        then:
+        result.response.status == HttpStatus.NO_CONTENT.value()
+    }
+
+    def "게시물 삭제 실패 - 존재하지 않는 게시물, 400 status와 예외메시지를 반환한다."() {
+        given:
+        def nonExistingPostId = 999L
+        postService.deletePost(nonExistingPostId) >> { throw new IllegalArgumentException("존재하지 않는 게시물입니다.") }
+
+        when:
+        def result = mockMvc.perform(
+                delete("/api/v1/posts/{id}", nonExistingPostId))
+                .andDo(print())
+                .andReturn()
+
+        then:
+        def content = result.response.getContentAsString()
+        final JsonNode responseBody = objectMapper.readTree(content)
+
+        result.response.status == HttpStatus.BAD_REQUEST.value()
+        responseBody.get("errorMessage").asText() == "존재하지 않는 게시물입니다."
+    }
+
+}

--- a/src/test/groovy/com/devtribe/devtribe_feed_service/post/application/PostServiceTest.groovy
+++ b/src/test/groovy/com/devtribe/devtribe_feed_service/post/application/PostServiceTest.groovy
@@ -53,20 +53,15 @@ class PostServiceTest extends Specification {
         given:
         def author = getUser(1L)
         def request = getCreatePostRequest(1L)
-
-        def expectedPost = request.toEntity(author)
-        postRepository.save(_ as Post) >> { args -> args[0] }
-
+        def savedPost = getPost(1L)
+        postRepository.save(_ as Post) >> savedPost
         userService.getUser(request.authorId()) >> author
 
         when:
         def actualPost = postService.createPost(request)
 
         then:
-        actualPost.getId() == expectedPost.getId()
-        actualPost.getTitle() == expectedPost.getTitle()
-        actualPost.getContent() == expectedPost.getContent()
-        actualPost.getUserId() == author.getId()
+        actualPost.id() == savedPost.getId()
     }
 
     def "존재하지 않은 작성자로 Post 생성 요청이 주어질 때, Post 생성에 실패한다."() {
@@ -105,11 +100,10 @@ class PostServiceTest extends Specification {
         def actual = postService.updatePost(postId, updatePostRequest)
 
         then:
-        actual.getId() == expected.getId()
-        actual.getTitle() == expected.getTitle()
-        actual.getContent() == expected.getContent()
-        actual.getThumbnail() == expected.getThumbnail()
-        actual.getPublication() == expected.getPublication()
+        actual.title() == expected.getTitle()
+        actual.content() == expected.getContent()
+        actual.thumbnail() == expected.getThumbnail()
+        actual.publication() == expected.getPublication()
     }
 
     def "작성자가 아닌 유저의 Post 수정 요청이 주어질 때, Post 수정에 실패한다."() {

--- a/src/test/groovy/com/devtribe/devtribe_feed_service/post/domain/FeedSortOptionTest.groovy
+++ b/src/test/groovy/com/devtribe/devtribe_feed_service/post/domain/FeedSortOptionTest.groovy
@@ -1,0 +1,17 @@
+package com.devtribe.devtribe_feed_service.post.domain
+
+import spock.lang.Specification
+
+class FeedSortOptionTest extends Specification {
+
+    def"null 값이 주어지면 최신순이 나와야한다."(){
+        given:
+        String value = null
+
+        when:
+        def feedSortOption = FeedSortOption.fromValue(value)
+
+        then:
+        FeedSortOption.BY_NEWEST == feedSortOption
+    }
+}

--- a/src/test/groovy/com/devtribe/devtribe_feed_service/test/fixtures/PostResponseFixture.groovy
+++ b/src/test/groovy/com/devtribe/devtribe_feed_service/test/fixtures/PostResponseFixture.groovy
@@ -1,0 +1,26 @@
+package com.devtribe.devtribe_feed_service.test.fixtures
+
+import com.devtribe.devtribe_feed_service.post.application.dtos.PostResponse
+import com.devtribe.devtribe_feed_service.post.domain.Publication
+
+import java.time.LocalDateTime
+
+class PostResponseFixture {
+
+    static List<PostResponse> createLatestPostResponse(int numberOfPost) {
+        LocalDateTime now = LocalDateTime.now()
+
+        (0..numberOfPost-1).collect { i ->
+            new PostResponse(
+                    (i + 1) as Long,
+                    (i + 1) as Long,
+                    "Title ${i + 1}",
+                    "Content of post ${i + 1}",
+                    "Thumbnail ${i + 1}",
+                    Publication.PUBLIC,
+                    now.minusMinutes(i),
+                    now.minusMinutes(i)
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 1. 연관 이슈 
- close: #15 
- depends on: #14 
  - #14 에서 분기되어 이어지는 브랜치입니다. 
  - 최신 변경점만 표시하기 위에 base를 `12-post-crud` 브랜치로 설정되어 있습니다.
  - 머지 승인주시면 main에 rebase 후에 머지해보겠습니다.

## 2. 작업 내용 

안녕하세요 @f-lab-moony 멘토님! 피드 조회(최신순, 추천순) 작업 내용에 관한 PR 올립니다! 아직 작성중이고 & PR 범위가 많아질 것 같아 데이터베이스 테스트 내용은 다음 PR로 올려보겠습니다. 부족함이 많지만 동적 쿼리 구현 로직이나 테스트 코드 피드백 주시면 너무 도움 많이될 것 같습니다! 🙇‍♂️

- 최신순/추천순별 피드 조회 로직 추가 
  - 커서 기반 페이지네이션 적용
- querydsl 의존성 및 설정 클래스 추가
  - 동적 쿼리 구현
- MockMVC를 이용한 PostController 테스트 추가

## 3. 고려해본 것들 & 고민되는 점
> enum의 사용 방안에 대해서

조회 정렬 방식(최신순/오래된/추천순/비추천순)별 피드 조회를 구현하면서 Enum을 사용해서 동적 쿼리를 구현하는데 유용하겠다고 생각돼서 Enum으로 정렬 옵션을 구현해봤습니다. 이 과정에서 이전에 말씀 주신 부분들이 생각나서 멘토님께 몇가지 확인받고 싶은 부분이 있습니다. 

1. 조회 정렬 방식(`?sort=lastest`)을 컨트롤러에서 인자로 받을때 String으로 받은 후 서비스 레이어에서 enum 으로 변환하도록 구현 
  - 현재 유효성 검사를 서비스 레이어에서 하고 있기 때문에 통일성을 위해
  - `@RequestParam` 에서 Enum으로 변환이 실패할 경우 예외처리를 따로 해줘야해서
라는 이유로 서비스 레이어에서 변환하도록 구현했습니다. 컨트롤러에서 입력을 받을때 Enum으로 받는게 나을까요?

2. 동적쿼리를 구현할때 사용할 수 있게, 열거형 상수에 `where(BooleanExpression)`, `order by(OrderSpecifier )` 조건도 같이 포함해서 구현했습니다. 요렇게 구현하니까 사용하는 시점에서는 편하고 코드들도 상수에 연관지을 수 있어서 좋은 장점이 있는것 같은데 쿼리 조건을 enum에 같이 구현하는게 조금 어색하게 느껴지는 것 같습니다. (쿼리가 repository와 떨어져 있는 것) 이런식으로 구현해도 괜찮을지 멘토님 의견이 궁금합니다.
