### PR TITLE
Redis 기반 게시글 추천/비추천 및 추천수 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	// security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/http/post-vote.http
+++ b/http/post-vote.http
@@ -1,0 +1,15 @@
+### 게시글 추천
+POST http://localhost:8080/api/v1/posts/1/upvote
+Content-Type: application/json
+
+### 게시글 비추천
+POST http://localhost:8080/api/v1/posts/1/downvote
+Content-Type: application/json
+
+### 게시글 투표 취소
+DELETE http://localhost:8080/api/v1/posts/1/unvote
+Content-Type: application/json
+
+### 게시글 추천/비추천 수 조회
+GET http://localhost:8080/api/v1/posts/1/vote
+Content-Type: application/json

--- a/src/main/java/com/devtribe/devtribe_feed_service/global/config/redis/LuaScriptConfig.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/global/config/redis/LuaScriptConfig.java
@@ -1,0 +1,38 @@
+package com.devtribe.devtribe_feed_service.global.config.redis;
+
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.data.redis.core.script.RedisScript;
+
+@Configuration
+public class LuaScriptConfig {
+
+    private static final String LUA_SCRIPT_PATH = "scripts/";
+
+    private static final String POST_VOTE = "post_vote.lua";
+    private static final String POST_UNVOTE = "post_unvote.lua";
+    private static final String POST_VOTE_COUNT = "post_vote_count.lua";
+
+    @Bean
+    public RedisScript<List> postVoteScript() {
+        return loadScript(POST_VOTE);
+    }
+
+    @Bean
+    public RedisScript<List> postUnvoteScript() {
+        return loadScript(POST_UNVOTE);
+    }
+
+    @Bean
+    public RedisScript<List> postVoteCountScript() {
+        return loadScript(POST_VOTE_COUNT);
+    }
+
+    private RedisScript<List> loadScript(String fileName) {
+        Resource scriptResource = new ClassPathResource(LUA_SCRIPT_PATH + fileName);
+        return RedisScript.of(scriptResource, List.class);
+    }
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/global/config/redis/RedisConfig.java
@@ -1,0 +1,22 @@
+package com.devtribe.devtribe_feed_service.global.config.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/global/config/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.devtribe.devtribe_feed_service.global.config.security.authentication.
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
@@ -42,6 +43,7 @@ public class SecurityConfig {
                     "/api/v1/auth/login",
                     "/api/v1/auth/logout").permitAll()
                 .requestMatchers("/api/v1/feeds/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/posts/*/vote").permitAll()
                 .requestMatchers("/api/v1/posts/**").authenticated()
                 .anyRequest().authenticated()
             )

--- a/src/main/java/com/devtribe/devtribe_feed_service/global/config/security/authentication/CustomUserDetail.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/global/config/security/authentication/CustomUserDetail.java
@@ -40,4 +40,8 @@ public class CustomUserDetail implements UserDetails, CredentialsContainer {
     public User getUser() {
         return user;
     }
+
+    public Long getUserId() {
+        return user.getId();
+    }
 }

--- a/src/main/java/com/devtribe/devtribe_feed_service/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/global/error/GlobalExceptionHandler.java
@@ -1,11 +1,13 @@
 package com.devtribe.devtribe_feed_service.global.error;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -13,6 +15,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponse> handleIllegalArgumentException(
         IllegalArgumentException exception
     ) {
+        log.debug("Invalid argument error: {}", exception.getMessage(), exception);
         ErrorResponse response = new ErrorResponse(exception.getMessage());
         return ResponseEntity.badRequest().body(response);
     }
@@ -21,6 +24,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleEnumMismatch(
         MethodArgumentTypeMismatchException exception
     ) {
+        log.debug("Type mismatch error: {}", exception.getMessage(), exception);
         ErrorResponse response = new ErrorResponse("올바르지 않은 요청 값입니다.");
         return ResponseEntity.badRequest().body(response);
     }
@@ -29,6 +33,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
         HttpMessageNotReadableException exception
     ) {
+        log.debug("Request parse error: {}", exception.getMessage(), exception);
         ErrorResponse response = new ErrorResponse("올바르지 않은 요청 값입니다.");
         return ResponseEntity.badRequest().body(response);
     }

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/api/PostController.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/api/PostController.java
@@ -55,7 +55,7 @@ public class PostController {
     }
 
     @PostMapping("/{id}/upvote")
-    public ResponseEntity<PostVoteResponse> upvotePost(
+    public ResponseEntity<PostVoteResponse> upvote(
         @PathVariable("id") Long postId,
         @AuthenticationPrincipal CustomUserDetail userDetail
     ) {
@@ -65,7 +65,7 @@ public class PostController {
     }
 
     @PostMapping("/{id}/downvote")
-    public ResponseEntity<PostVoteResponse> downvotePost(
+    public ResponseEntity<PostVoteResponse> downvote(
         @PathVariable("id") Long postId,
         @AuthenticationPrincipal CustomUserDetail userDetail
     ) {

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/api/PostController.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/api/PostController.java
@@ -80,7 +80,7 @@ public class PostController {
         @AuthenticationPrincipal CustomUserDetail userDetail
     ) {
         Long userId = userDetail.getUserId();
-        voteService.unvote(postId, upvotePostRequest(userId));
+        voteService.unvote(postId, userId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/api/PostController.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/api/PostController.java
@@ -14,6 +14,7 @@ import com.devtribe.devtribe_feed_service.post.application.dtos.UpdatePostRespon
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -52,6 +53,14 @@ public class PostController {
     public ResponseEntity<Void> deletePost(@PathVariable("id") Long id) {
         postService.deletePost(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{id}/vote")
+    public ResponseEntity<PostVoteResponse> voteCount(
+        @PathVariable("id") Long postId
+    ){
+        PostVoteResponse responseBody = voteService.getVoteCount(postId);
+        return ResponseEntity.ok(responseBody);
     }
 
     @PostMapping("/{id}/upvote")

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/api/PostController.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/api/PostController.java
@@ -1,11 +1,18 @@
 package com.devtribe.devtribe_feed_service.post.api;
 
+import static com.devtribe.devtribe_feed_service.post.application.dtos.VoteRequest.downvotePostRequest;
+import static com.devtribe.devtribe_feed_service.post.application.dtos.VoteRequest.upvotePostRequest;
+
+import com.devtribe.devtribe_feed_service.global.config.security.authentication.CustomUserDetail;
 import com.devtribe.devtribe_feed_service.post.application.PostService;
+import com.devtribe.devtribe_feed_service.post.application.VoteService;
 import com.devtribe.devtribe_feed_service.post.application.dtos.CreatePostRequest;
 import com.devtribe.devtribe_feed_service.post.application.dtos.CreatePostResponse;
+import com.devtribe.devtribe_feed_service.post.application.dtos.PostVoteResponse;
 import com.devtribe.devtribe_feed_service.post.application.dtos.UpdatePostRequest;
 import com.devtribe.devtribe_feed_service.post.application.dtos.UpdatePostResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,9 +26,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class PostController {
 
     private final PostService postService;
+    private final VoteService voteService;
 
-    public PostController(PostService postService) {
+    public PostController(PostService postService, VoteService voteService) {
         this.postService = postService;
+        this.voteService = voteService;
     }
 
     @PostMapping
@@ -43,5 +52,25 @@ public class PostController {
     public ResponseEntity<Void> deletePost(@PathVariable("id") Long id) {
         postService.deletePost(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{id}/upvote")
+    public ResponseEntity<PostVoteResponse> upvotePost(
+        @PathVariable("id") Long postId,
+        @AuthenticationPrincipal CustomUserDetail userDetail
+    ) {
+        Long userId = userDetail.getUserId();
+        PostVoteResponse responseBody = voteService.vote(postId, upvotePostRequest(userId));
+        return ResponseEntity.ok(responseBody);
+    }
+
+    @PostMapping("/{id}/downvote")
+    public ResponseEntity<PostVoteResponse> downvotePost(
+        @PathVariable("id") Long postId,
+        @AuthenticationPrincipal CustomUserDetail userDetail
+    ) {
+        Long userId = userDetail.getUserId();
+        PostVoteResponse responseBody = voteService.vote(postId, downvotePostRequest(userId));
+        return ResponseEntity.ok(responseBody);
     }
 }

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/api/PostController.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/api/PostController.java
@@ -73,4 +73,15 @@ public class PostController {
         PostVoteResponse responseBody = voteService.vote(postId, downvotePostRequest(userId));
         return ResponseEntity.ok(responseBody);
     }
+
+    @DeleteMapping("/{id}/unvote")
+    public ResponseEntity<Void> unvote(
+        @PathVariable("id") Long postId,
+        @AuthenticationPrincipal CustomUserDetail userDetail
+    ) {
+        Long userId = userDetail.getUserId();
+        voteService.unvote(postId, upvotePostRequest(userId));
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/application/VoteService.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/application/VoteService.java
@@ -1,0 +1,100 @@
+package com.devtribe.devtribe_feed_service.post.application;
+
+import com.devtribe.devtribe_feed_service.post.application.dtos.PostVoteResponse;
+import com.devtribe.devtribe_feed_service.post.application.dtos.VoteRequest;
+import com.devtribe.devtribe_feed_service.post.domain.vote.VoteType;
+import java.util.List;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Service;
+
+@Service
+public class VoteService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private final String script = """
+        local setKey = KEYS[1]
+        local removeCountKey = KEYS[2]
+        local addCountKey = KEYS[3]
+        
+        local removeValue = ARGV[1]
+        local addValue = ARGV[2]
+        local id = ARGV[3]
+        
+        -- 비추천 제거 시 실제로 제거되었으면 카운트 감소
+        if redis.call('SREM', setKey, removeValue) == 1 then
+            redis.call('ZINCRBY', removeCountKey, -1, id)
+        end
+        
+        -- 추천 추가
+        if redis.call('SADD', setKey, addValue) == 1 then
+            redis.call('ZINCRBY', addCountKey, 1, id)
+        end
+        """;
+
+    private final String cancelScript = """
+        local setKey = KEYS[1]
+        local countKey = KEYS[2]
+        
+        local removeValue = ARGV[1]
+        local id = ARGV[2]
+        
+        -- 비추천 제거 시 실제로 제거되었으면 카운트 감소
+        if redis.call('SREM', setKey, removeValue) == 1 then
+            redis.call('ZINCRBY', countKey, -1, id)
+        end
+        """;
+
+    public VoteService(RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public PostVoteResponse vote(Long postId, VoteRequest voteRequest) {
+        String key = "post:" + postId + ":votes";
+        String upvoteCountKey = "post:upvoteCount";
+        String downvoteCountKey = "post:downvoteCount";
+        String upvote = voteRequest.userId() + ":" + VoteType.UPVOTE;
+        String downvote = voteRequest.userId() + ":" + VoteType.DOWNVOTE;
+
+        if (voteRequest.voteType() == VoteType.UPVOTE) {
+            redisTemplate.execute(
+                new DefaultRedisScript<>(script, String.class),
+                List.of(key, downvoteCountKey, upvoteCountKey),
+                downvote, upvote, postId.toString()
+            );
+        } else {
+            redisTemplate.execute(
+                new DefaultRedisScript<>(script, String.class),
+                List.of(key, upvoteCountKey, downvoteCountKey),
+                upvote, downvote, postId.toString()
+            );
+        }
+
+        return new PostVoteResponse();
+    }
+
+    public PostVoteResponse cancelVote(Long postId, VoteRequest voteRequest) {
+        String key = "post:" + postId + ":votes";
+        String upvoteCountKey = "post:upvoteCount";
+        String downvoteCountKey = "post:downvoteCount";
+        String upvote = voteRequest.userId() + ":" + VoteType.UPVOTE;
+        String downvote = voteRequest.userId() + ":" + VoteType.DOWNVOTE;
+
+        if (voteRequest.voteType() == VoteType.UPVOTE) {
+            redisTemplate.execute(
+                new DefaultRedisScript<>(cancelScript, String.class),
+                List.of(key, upvoteCountKey),
+                upvote, postId.toString()
+            );
+        } else {
+            redisTemplate.execute(
+                new DefaultRedisScript<>(cancelScript, String.class),
+                List.of(key, downvoteCountKey),
+                downvote, postId.toString()
+            );
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/application/VoteService.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/application/VoteService.java
@@ -74,7 +74,7 @@ public class VoteService {
         return new PostVoteResponse();
     }
 
-    public PostVoteResponse cancelVote(Long postId, VoteRequest voteRequest) {
+    public PostVoteResponse unvote(Long postId, VoteRequest voteRequest) {
         String key = "post:" + postId + ":votes";
         String upvoteCountKey = "post:upvoteCount";
         String downvoteCountKey = "post:downvoteCount";

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/application/VoteService.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/application/VoteService.java
@@ -74,7 +74,7 @@ public class VoteService {
         return new PostVoteResponse();
     }
 
-    public PostVoteResponse unvote(Long postId, VoteRequest voteRequest) {
+    public PostVoteResponse unvote(Long postId, Long userId) {
         String key = "post:" + postId + ":votes";
         String upvoteCountKey = "post:upvoteCount";
         String downvoteCountKey = "post:downvoteCount";

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/application/VoteService.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/application/VoteService.java
@@ -2,91 +2,59 @@ package com.devtribe.devtribe_feed_service.post.application;
 
 import com.devtribe.devtribe_feed_service.post.application.dtos.PostVoteResponse;
 import com.devtribe.devtribe_feed_service.post.application.dtos.VoteRequest;
-import com.devtribe.devtribe_feed_service.post.domain.vote.VoteType;
 import java.util.List;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
 
 @Service
 public class VoteService {
 
     private final RedisTemplate<String, String> redisTemplate;
+    private final RedisScript<List> postVoteScript;
+    private final RedisScript<List> postUnvoteScript;
 
-    private final String script = """
-        local setKey = KEYS[1]
-        local removeCountKey = KEYS[2]
-        local addCountKey = KEYS[3]
-        
-        local removeValue = ARGV[1]
-        local addValue = ARGV[2]
-        local id = ARGV[3]
-        
-        -- 비추천 제거 시 실제로 제거되었으면 카운트 감소
-        if redis.call('SREM', setKey, removeValue) == 1 then
-            redis.call('ZINCRBY', removeCountKey, -1, id)
-        end
-        
-        -- 추천 추가
-        if redis.call('SADD', setKey, addValue) == 1 then
-            redis.call('ZINCRBY', addCountKey, 1, id)
-        end
-        """;
-
-    private final String cancelScript = """
-        local userId = ARGV[1]
-        
-        local removedUp = redis.call("SREM", KEYS[1], userId .. ":UPVOTE")
-        if removedUp == 1 then
-            redis.call("ZINCRBY", KEYS[2], -1, userId)
-            return 1
-        end
-        
-        local removedDown = redis.call("SREM", KEYS[1], userId .. ":DOWNVOTE")
-        if removedDown == 1 then
-            redis.call("ZINCRBY", KEYS[3], -1, userId)
-            return 1
-        end
-        
-        return 0
-        """;
-
-    public VoteService(RedisTemplate<String, String> redisTemplate) {
+    public VoteService(
+        RedisTemplate<String, String> redisTemplate,
+        RedisScript<List> postVoteScript,
+        RedisScript<List> postUnvoteScript
+    ) {
         this.redisTemplate = redisTemplate;
+        this.postVoteScript = postVoteScript;
+        this.postUnvoteScript = postUnvoteScript;
     }
 
     public PostVoteResponse vote(Long postId, VoteRequest voteRequest) {
         String key = "post:" + postId + ":votes";
         String upvoteCountKey = "post:upvoteCount";
         String downvoteCountKey = "post:downvoteCount";
-        String upvote = voteRequest.userId() + ":" + VoteType.UPVOTE;
-        String downvote = voteRequest.userId() + ":" + VoteType.DOWNVOTE;
 
-        if (voteRequest.voteType() == VoteType.UPVOTE) {
-            redisTemplate.execute(
-                new DefaultRedisScript<>(script, String.class),
-                List.of(key, downvoteCountKey, upvoteCountKey),
-                downvote, upvote, postId.toString()
-            );
-        } else {
-            redisTemplate.execute(
-                new DefaultRedisScript<>(script, String.class),
-                List.of(key, upvoteCountKey, downvoteCountKey),
-                upvote, downvote, postId.toString()
-            );
-        }
-
-        return new PostVoteResponse();
+        List<String> result = redisTemplate.execute(
+            postVoteScript,
+            List.of(key, upvoteCountKey, downvoteCountKey),
+            postId.toString(), voteRequest.userId().toString(), voteRequest.voteType().toString()
+        );
+        return getPostVoteResponse(postId, result);
     }
 
-    public void unvote(Long postId, Long userId) {
+    public PostVoteResponse unvote(Long postId, Long userId) {
         String setKey = "post:" + postId + ":votes";
         String upvoteCountKey = "post:upvoteCount";
         String downvoteCountKey = "post:downvoteCount";
 
-        redisTemplate.execute(new DefaultRedisScript<>(cancelScript, String.class),
+        List<String> result = redisTemplate.execute(
+            postUnvoteScript,
             List.of(setKey, upvoteCountKey, downvoteCountKey),
-            userId
+            postId.toString(), userId.toString()
         );
+        return getPostVoteResponse(postId, result);
     }
+
+    private PostVoteResponse getPostVoteResponse(Long postId, List<String> result) {
+        /// TODO null - check 개선 필요
+        Integer upvoteCount = Integer.parseInt(result.get(0) == null ? "0" : result.get(0));
+        Integer downvoteCount = Integer.parseInt(result.get(1) == null ? "0" : result.get(1));
+        return new PostVoteResponse(postId, upvoteCount, downvoteCount);
+    }
+
 }

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/application/dtos/PostVoteResponse.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/application/dtos/PostVoteResponse.java
@@ -1,5 +1,5 @@
 package com.devtribe.devtribe_feed_service.post.application.dtos;
 
-public record PostVoteResponse() {
+public record PostVoteResponse(Long postId, Integer upvoteCount, Integer downvoteCount) {
 
 }

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/application/dtos/PostVoteResponse.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/application/dtos/PostVoteResponse.java
@@ -1,0 +1,5 @@
+package com.devtribe.devtribe_feed_service.post.application.dtos;
+
+public record PostVoteResponse() {
+
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/application/dtos/VoteRequest.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/application/dtos/VoteRequest.java
@@ -1,0 +1,25 @@
+package com.devtribe.devtribe_feed_service.post.application.dtos;
+
+import com.devtribe.devtribe_feed_service.post.domain.vote.PostVote;
+import com.devtribe.devtribe_feed_service.post.domain.vote.VoteType;
+
+public record VoteRequest(
+    Long userId,
+    VoteType voteType
+) {
+
+    public static VoteRequest upvotePostRequest(Long userId) {
+        return new VoteRequest(userId, VoteType.UPVOTE);
+    }
+
+    public static VoteRequest downvotePostRequest(Long userId) {
+        return new VoteRequest(userId, VoteType.DOWNVOTE);
+    }
+
+    public PostVote toEntity() {
+        return PostVote.builder()
+            .userId(this.userId)
+            .voteType(this.voteType)
+            .build();
+    }
+}

--- a/src/main/java/com/devtribe/devtribe_feed_service/post/domain/vote/PostVote.java
+++ b/src/main/java/com/devtribe/devtribe_feed_service/post/domain/vote/PostVote.java
@@ -20,9 +20,9 @@ import org.springframework.data.annotation.LastModifiedDate;
 
 @Getter
 @Entity
-@Table(name = "vote")
+@Table(name = "post_vote")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Vote {
+public class PostVote {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,12 +31,8 @@ public class Vote {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @Column(name = "target_id", nullable = false)
-    private Long targetId;
-
-    @Enumerated(value = EnumType.STRING)
-    @Column(name = "target_type", nullable = false)
-    private TargetType targetType;
+    @Column(name = "post_id", nullable = false)
+    private Long postId;
 
     @Enumerated(value = EnumType.STRING)
     @Column(name = "vote_type", nullable = false)
@@ -59,10 +55,9 @@ public class Vote {
     private Long updatedBy;
 
     @Builder
-    public Vote(Long targetId, Long userId, TargetType targetType, VoteType voteType) {
-        this.targetId = targetId;
+    public PostVote(Long postId, Long userId, VoteType voteType) {
+        this.postId = postId;
         this.userId = userId;
-        this.targetType = targetType;
         this.voteType = voteType;
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -3,10 +3,10 @@ spring:
     name: devtribe-feed-service
 
   datasource:
-    url: jdbc:mysql://localhost:3306/devtribe-feed
+    url: ${DB_URL}
     driver-class-name: com.mysql.cj.jdbc.Driver
-    username: sa
-    password: password
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     hikari:
       minimum-idle: 10
       maximum-pool-size: 200

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,6 +13,11 @@ spring:
       idle-timeout: 30000
       connection-timeout: 20000
 
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
   jpa:
     hibernate:
       ddl-auto: validate

--- a/src/main/resources/db/migration/V6__rename_table_vote_to_post_vote.sql
+++ b/src/main/resources/db/migration/V6__rename_table_vote_to_post_vote.sql
@@ -1,0 +1,4 @@
+# 테이블 명 변경
+ALTER TABLE `devtribe-feed`.vote
+    RENAME TO `devtribe-feed`.post_vote;
+

--- a/src/main/resources/db/migration/V7__alter_post_vote_column.sql
+++ b/src/main/resources/db/migration/V7__alter_post_vote_column.sql
@@ -1,0 +1,7 @@
+# target_id 컬럼명 변경
+ALTER TABLE `devtribe-feed`.post_vote
+    CHANGE target_id post_id BIGINT NOT NULL;
+
+# target_type 컬럼 제거
+ALTER TABLE `devtribe-feed`.post_vote
+DROP COLUMN target_type;

--- a/src/main/resources/scripts/post_unvote.lua
+++ b/src/main/resources/scripts/post_unvote.lua
@@ -1,0 +1,18 @@
+local setKey, upCountKey, downCountKey = KEYS[1], KEYS[2], KEYS[3]
+local postId, userId = ARGV[1], ARGV[2]
+
+local removedUp = redis.call("SREM", setKey, userId .. ":UPVOTE")
+if removedUp == 1 then
+    redis.call("ZINCRBY", upCountKey, -1, postId)
+end
+
+local removedDown = redis.call("SREM", setKey, userId .. ":DOWNVOTE")
+if removedDown == 1 then
+    redis.call("ZINCRBY", downCountKey, -1, postId)
+end
+
+-- postId의 추천 수/ 비추천수 조회
+local upScore = redis.call("ZSCORE", upCountKey, postId)
+local downScore = redis.call("ZSCORE", downCountKey, postId)
+
+return {upScore, downScore}

--- a/src/main/resources/scripts/post_vote.lua
+++ b/src/main/resources/scripts/post_vote.lua
@@ -1,0 +1,23 @@
+local setKey, upCountKey, downCountKey = KEYS[1], KEYS[2], KEYS[3]
+local postId, userId, voteType = ARGV[1], ARGV[2], ARGV[3]
+
+local addKey = userId..":"..voteType
+-- voteType == UPVOTE ? DOWNVOTE : UPVOTE
+local remKey = userId..":"..(voteType=="UPVOTE" and "DOWNVOTE" or "UPVOTE")
+
+-- voteType == UPVOTE ? upCountKey : downCountKey
+local countAdd = (voteType=="UPVOTE" and upCountKey or downCountKey)
+local countRem = (voteType=="UPVOTE" and downCountKey or upCountKey)
+
+if redis.call("SREM", setKey, remKey) == 1 then
+  redis.call("ZINCRBY", countRem, -1, postId)
+end
+if redis.call("SADD", setKey, addKey) == 1 then
+  redis.call("ZINCRBY", countAdd, 1, postId)
+end
+
+-- postId의 추천 수/ 비추천수 조회
+local upScore = redis.call("ZSCORE", upCountKey, postId)
+local downScore = redis.call("ZSCORE", downCountKey, postId)
+
+return {upScore, downScore}

--- a/src/main/resources/scripts/post_vote_count.lua
+++ b/src/main/resources/scripts/post_vote_count.lua
@@ -1,0 +1,8 @@
+local upCountKey, downCountKey = KEYS[1], KEYS[2]
+local postId = ARGV[1]
+
+-- postId의 추천 수/ 비추천수 조회
+local upScore = redis.call("ZSCORE", upCountKey, postId)
+local downScore = redis.call("ZSCORE", downCountKey, postId)
+
+return {upScore, downScore}


### PR DESCRIPTION
## 1. 연관 이슈 
- related: #30 

## 2. 작업 내용 

Redis 기반의 게시글 추천/비추천 및 조회 기능을 추가했습니다. 

- [x] 게시글 추천/비추천 추가 및 취소 로직 구현, 
  - Redis의 Set 자료구조를 활용. 
  - 예시) `post:{postId}:vote`: {`userId:UPVOTE`, `userId:DOWNVOTE`, ...}
- [x] 게시글 추천수, 비추천수 조회 기능 추가
  - Redis의 ZSet 자료구조를 활용, 
  - 예시)`post:upvoteCount`: {`postId: score`, `1: 10` ...}
  - 예시)`post:downvoteCount`: {`postId: score`, `1: 2` ...}
- [x] Lua Script 작성 및 연동
  - 추천/비추천 상태 변경 + 추천/비추천 count 증감연산 일관성있게 원자적으로 처리하기 위한 목적으로 Lua Script 활용

> 안녕하세요 @f-lab-moony 멘토님 게시글 추천/비추천 기능 구현 내용 공유드립니다. 
>
> 게시글 토글방식의 추천/비추천 기능의 경우 1)데이터의 수정이 빈번하게 일어남 + 2)유명인의 게시글의 경우 많은 추천/비추천이 몰려 DB에 쓰기부하가 높을 수 있다는 특성을 고려해 캐시에 먼저 쓰고 DB에 업데이트하는 캐시 전략인 write-back 방식을 구현하려고 합니다.
>
> 구현 방식이나 코드에서 피드백 주시면 도움 많이될 것 같습니다! 🙇‍♂️

## 3. 이후 작업

- [ ] 데이터 유실 방지를 위한 Spring 배치를 통한 RDB에 반영
- [ ] 캐시 삭제 전략 도입 

## 4. 고려해본 것들 & 고민되는 점
> 캐시 삭제 전략에 대해 

현재 구현에서 캐시 삭제 전략에 대해서는 고려되지 않았습니다. Redis도 유한한 자원이다보니까 결국에 어떤 데이터를 얼마나 캐싱해둘거냐라는 고민이 들게 되는 것 같습니다. 고려하고 있는 방식은 LFU(가장 사용빈도가 낮은) 게시글 추천/비추천 데이터 순으로 삭제하고 싶습니다. 이런 고민에서 몇 가지 궁금증 생겨 질문드립니다!

- 캐시 정책을 세우기 위해서 참고하는 지표나 보편적인 방법들이 존재하는지 궁금합니다!
- 캐시에서 삭제된 후 다시 추천/비추천 요청이 들어왔을때의 경우 
  - 이 경우 DB에서 해당 게시글의 추천/비추천 정보를 다시 캐시로 불러와야하는데 이를 주로 서비스 코드에서 직접 구현하는 방식인지 아니면 캐시 미스의 경우 Spring에서 처리할 수 있는 방법이 존재하는지 궁금합니다. 만약 존재한다면 연관 키워드 알려주시면 찾아보겠습니다.