### PR TITLE
추천/비추천 기능을 기존 Post도메인에서 Vote도메인으로 분리

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
 	id("java")
 	id("org.springframework.boot") version "3.4.2"
+	id("io.spring.dependency-management") version "1.1.4"
 }
 
 java {
@@ -9,7 +10,12 @@ java {
 	}
 }
 
-val queryDslVersion = "5.0.0"
+repositories {
+	mavenCentral()
+}
+
+ext["springCloudVersion"] = "2024.0.0"
+ext["queryDslVersion"] = "5.0.0"
 
 allprojects {
 
@@ -39,8 +45,8 @@ subprojects {
 
 	dependencies {
 		compileOnly("org.projectlombok:lombok")
-		implementation("com.querydsl:querydsl-jpa:$queryDslVersion:jakarta")
-		annotationProcessor("com.querydsl:querydsl-apt:$queryDslVersion:jakarta")
+		implementation("com.querydsl:querydsl-jpa:${property("queryDslVersion")}:jakarta")
+		annotationProcessor("com.querydsl:querydsl-apt:${property("queryDslVersion")}:jakarta")
 		annotationProcessor("org.projectlombok:lombok")
 		testImplementation(platform("org.junit:junit-bom:5.10.0"))
 		testImplementation("org.junit.jupiter:junit-jupiter")
@@ -48,6 +54,12 @@ subprojects {
 		testImplementation("org.spockframework:spock-core:2.4-M4-groovy-4.0")
 		testImplementation("org.spockframework:spock-spring:2.4-M4-groovy-4.0")
 
+	}
+
+	dependencyManagement {
+		imports {
+			mavenBom("org.springframework.cloud:spring-cloud-dependencies:${property("springCloudVersion")}")
+		}
 	}
 
 	configurations {

--- a/devtribe-feed-api/build.gradle.kts
+++ b/devtribe-feed-api/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.cloud:spring-cloud-starter-stream-kafka")
     implementation("org.testcontainers:mysql")
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-mysql")

--- a/devtribe-feed-api/src/main/java/com/devtribe/domain/post/api/PostController.java
+++ b/devtribe-feed-api/src/main/java/com/devtribe/domain/post/api/PostController.java
@@ -5,14 +5,8 @@ import com.devtribe.domain.post.application.dtos.CreatePostRequest;
 import com.devtribe.domain.post.application.dtos.CreatePostResponse;
 import com.devtribe.domain.post.application.dtos.UpdatePostRequest;
 import com.devtribe.domain.post.application.dtos.UpdatePostResponse;
-import com.devtribe.domain.vote.application.VoteService;
-import com.devtribe.domain.vote.application.dtos.PostVoteResponse;
-import com.devtribe.domain.vote.application.dtos.VoteRequest;
-import com.devtribe.global.security.CustomUserDetail;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -25,11 +19,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class PostController {
 
     private final PostService postService;
-    private final VoteService voteService;
 
-    public PostController(PostService postService, VoteService voteService) {
+    public PostController(PostService postService) {
         this.postService = postService;
-        this.voteService = voteService;
     }
 
     @PostMapping
@@ -50,44 +42,6 @@ public class PostController {
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deletePost(@PathVariable("id") Long id) {
         postService.deletePost(id);
-        return ResponseEntity.noContent().build();
-    }
-
-    @GetMapping("/{id}/vote")
-    public ResponseEntity<PostVoteResponse> voteCount(
-        @PathVariable("id") Long postId
-    ){
-        PostVoteResponse responseBody = voteService.getVoteCount(postId);
-        return ResponseEntity.ok(responseBody);
-    }
-
-    @PostMapping("/{id}/upvote")
-    public ResponseEntity<PostVoteResponse> upvote(
-        @PathVariable("id") Long postId,
-        @AuthenticationPrincipal CustomUserDetail userDetail
-    ) {
-        Long userId = userDetail.getUserId();
-        PostVoteResponse responseBody = voteService.vote(postId, VoteRequest.upvotePostRequest(userId));
-        return ResponseEntity.ok(responseBody);
-    }
-
-    @PostMapping("/{id}/downvote")
-    public ResponseEntity<PostVoteResponse> downvote(
-        @PathVariable("id") Long postId,
-        @AuthenticationPrincipal CustomUserDetail userDetail
-    ) {
-        Long userId = userDetail.getUserId();
-        PostVoteResponse responseBody = voteService.vote(postId, VoteRequest.downvotePostRequest(userId));
-        return ResponseEntity.ok(responseBody);
-    }
-
-    @DeleteMapping("/{id}/unvote")
-    public ResponseEntity<Void> unvote(
-        @PathVariable("id") Long postId,
-        @AuthenticationPrincipal CustomUserDetail userDetail
-    ) {
-        Long userId = userDetail.getUserId();
-        voteService.unvote(postId, userId);
         return ResponseEntity.noContent().build();
     }
 

--- a/devtribe-feed-api/src/main/java/com/devtribe/domain/vote/api/VoteController.java
+++ b/devtribe-feed-api/src/main/java/com/devtribe/domain/vote/api/VoteController.java
@@ -1,0 +1,55 @@
+package com.devtribe.domain.vote.api;
+
+import com.devtribe.domain.vote.application.VoteService;
+import com.devtribe.domain.vote.application.dtos.PostVoteResponse;
+import com.devtribe.domain.vote.application.dtos.VoteRequest;
+import com.devtribe.global.security.CustomUserDetail;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/votes")
+public class VoteController {
+
+    private final VoteService voteService;
+
+    public VoteController(VoteService voteService) {
+        this.voteService = voteService;
+    }
+
+    @GetMapping("/post/{id}")
+    public PostVoteResponse voteCount(
+        @PathVariable("id") Long postId
+    ) {
+        return voteService.getVoteCount(postId);
+    }
+
+    @PostMapping("post/{id}")
+    public PostVoteResponse vote(
+        @PathVariable("id") Long postId,
+        @RequestBody VoteRequest voteType,
+        @AuthenticationPrincipal CustomUserDetail userDetail
+    ) {
+        log.info("voteType: {}", voteType);
+        return voteService.vote(postId, userDetail.getUserId(), voteType);
+    }
+
+    @DeleteMapping("post/{id}")
+    public ResponseEntity<Void> unvote(
+        @PathVariable("id") Long postId,
+        @AuthenticationPrincipal CustomUserDetail userDetail
+    ) {
+        Long userId = userDetail.getUserId();
+        voteService.unvote(postId, userId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/devtribe-feed-api/src/main/java/com/devtribe/domain/vote/application/VoteService.java
+++ b/devtribe-feed-api/src/main/java/com/devtribe/domain/vote/application/VoteService.java
@@ -43,13 +43,13 @@ public class VoteService {
         return String.format(POST_VOTES_KEY, postId);
     }
 
-    public PostVoteResponse vote(Long postId, VoteRequest voteRequest) {
+    public PostVoteResponse vote(Long postId, Long userId, VoteRequest voteRequest) {
         Post post = postService.getPost(postId);
 
         List<String> result = redisTemplate.execute(
             postVoteScript,
             List.of(getPostVotesKey(post.getId()), UPVOTE_COUNT_KEY, DOWNVOTE_COUNT_KEY),
-            post.getId().toString(), voteRequest.userId().toString(), voteRequest.voteType().toString()
+            post.getId().toString(), userId.toString(), voteRequest.voteType().toString()
         );
         return getPostVoteResponse(postId, result);
     }

--- a/devtribe-feed-api/src/main/java/com/devtribe/domain/vote/application/dtos/VoteRequest.java
+++ b/devtribe-feed-api/src/main/java/com/devtribe/domain/vote/application/dtos/VoteRequest.java
@@ -1,25 +1,9 @@
 package com.devtribe.domain.vote.application.dtos;
 
-import com.devtribe.domain.vote.entity.PostVoteLog;
 import com.devtribe.domain.vote.entity.VoteType;
 
 public record VoteRequest(
-    Long userId,
     VoteType voteType
 ) {
 
-    public static VoteRequest upvotePostRequest(Long userId) {
-        return new VoteRequest(userId, VoteType.UPVOTE);
-    }
-
-    public static VoteRequest downvotePostRequest(Long userId) {
-        return new VoteRequest(userId, VoteType.DOWNVOTE);
-    }
-
-    public PostVoteLog toEntity() {
-        return PostVoteLog.builder()
-            .userId(this.userId)
-            .voteType(this.voteType)
-            .build();
-    }
 }

--- a/devtribe-feed-api/src/main/java/com/devtribe/domain/vote/application/dtos/VoteRequest.java
+++ b/devtribe-feed-api/src/main/java/com/devtribe/domain/vote/application/dtos/VoteRequest.java
@@ -1,6 +1,6 @@
 package com.devtribe.domain.vote.application.dtos;
 
-import com.devtribe.domain.vote.entity.PostVote;
+import com.devtribe.domain.vote.entity.PostVoteLog;
 import com.devtribe.domain.vote.entity.VoteType;
 
 public record VoteRequest(
@@ -16,8 +16,8 @@ public record VoteRequest(
         return new VoteRequest(userId, VoteType.DOWNVOTE);
     }
 
-    public PostVote toEntity() {
-        return PostVote.builder()
+    public PostVoteLog toEntity() {
+        return PostVoteLog.builder()
             .userId(this.userId)
             .voteType(this.voteType)
             .build();

--- a/devtribe-feed-api/src/main/resources/db/migration/V8__rename_table_post_vote_to_post_vote_log.sql
+++ b/devtribe-feed-api/src/main/resources/db/migration/V8__rename_table_post_vote_to_post_vote_log.sql
@@ -1,0 +1,3 @@
+# 테이블 명 변경 (post_vote -> post_vote_log)
+ALTER TABLE `devtribe-feed`.post_vote
+    RENAME TO `devtribe-feed`.post_vote_log;

--- a/devtribe-feed-api/src/main/resources/db/migration/V9__add_post_vote_count_table.sql
+++ b/devtribe-feed-api/src/main/resources/db/migration/V9__add_post_vote_count_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE post_vote_count
+(
+    post_id    BIGINT       NOT NULL,
+    vote_type  VARCHAR(255) NOT NULL,
+    vote_count INT UNSIGNED NOT NULL DEFAULT 0,
+    created_at TIMESTAMP             DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP             DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (post_id, vote_type)
+);

--- a/devtribe-feed-api/src/test/groovy/com/devtribe/integration/api/post/PostControllerTest.groovy
+++ b/devtribe-feed-api/src/test/groovy/com/devtribe/integration/api/post/PostControllerTest.groovy
@@ -7,7 +7,6 @@ import com.devtribe.domain.post.application.dtos.CreatePostResponse
 import com.devtribe.domain.post.application.dtos.UpdatePostRequest
 import com.devtribe.domain.post.application.dtos.UpdatePostResponse
 import com.devtribe.domain.post.entity.Publication
-import com.devtribe.domain.vote.application.VoteService
 import com.devtribe.integration.config.NoSecurityWebMvcTest
 import com.devtribe.integration.config.TestSecurityConfig
 import com.fasterxml.jackson.databind.JsonNode
@@ -35,8 +34,6 @@ class PostControllerTest extends Specification {
     ObjectMapper objectMapper
     @SpringBean
     PostService postService = Mock(PostService)
-    @SpringBean
-    VoteService voteService = Mock(VoteService)
 
     def "게시물 생성 성공 - 200 status와 게시물 id를 반환"() {
         given:

--- a/devtribe-feed-consumer/build.gradle.kts
+++ b/devtribe-feed-consumer/build.gradle.kts
@@ -1,4 +1,5 @@
 dependencies {
     implementation(project(mapOf("path" to ":devtribe-feed-core")))
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.cloud:spring-cloud-starter-stream-kafka")
 }

--- a/devtribe-feed-core/src/main/java/com/devtribe/domain/vote/entity/PostVoteLog.java
+++ b/devtribe-feed-core/src/main/java/com/devtribe/domain/vote/entity/PostVoteLog.java
@@ -20,9 +20,9 @@ import org.springframework.data.annotation.LastModifiedDate;
 
 @Getter
 @Entity
-@Table(name = "post_vote")
+@Table(name = "post_vote_log")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PostVote {
+public class PostVoteLog {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -55,7 +55,7 @@ public class PostVote {
     private Long updatedBy;
 
     @Builder
-    public PostVote(Long postId, Long userId, VoteType voteType) {
+    public PostVoteLog(Long postId, Long userId, VoteType voteType) {
         this.postId = postId;
         this.userId = userId;
         this.voteType = voteType;

--- a/http/post-vote.http
+++ b/http/post-vote.http
@@ -1,15 +1,23 @@
 ### 게시글 추천
-POST http://localhost:8080/api/v1/posts/1/upvote
+POST http://localhost:8080/api/v1/votes/post/1
 Content-Type: application/json
+
+{
+  "voteType": "UPVOTE"
+}
 
 ### 게시글 비추천
-POST http://localhost:8080/api/v1/posts/1/downvote
+POST http://localhost:8080/api/v1/votes/post/1
 Content-Type: application/json
 
+{
+  "voteType": "DOWNVOTE"
+}
+
 ### 게시글 투표 취소
-DELETE http://localhost:8080/api/v1/posts/1/unvote
+DELETE http://localhost:8080/api/v1/votes/post/1
 Content-Type: application/json
 
 ### 게시글 추천/비추천 수 조회
-GET http://localhost:8080/api/v1/posts/1/vote
+GET http://localhost:8080/api/v1/votes/post/1
 Content-Type: application/json


### PR DESCRIPTION
## 1. 연관 이슈 
- related: #34 

## 2. 작업 내용 

기존 PostController에 있던 추천/비추천 관련 API를 VoteController로 분리하였습니다.
> Post에서 게시글 이외의 많은 책임을 가지는 것을 막기 위해 분리.
> Vote 도메인의 독립성과 확장성을 고려. 

- [x] 추천/비추천 관련 API를 VoteController로 분리
- [x] 기존 PostVote 엔티티를다음과 같이 두 개의 엔티티로 분리
  - `PostVoteLog`: 개별 유저의 추천/비추천 이력을 저장
  - `PostVoteCount`: 게시글별 총 추천/비추천 수를 집계


> 안녕하세요 @f-lab-moony 멘토님 추천/비추천 기능 분리 공유드립니다. 
> 추가로 기존 투표 엔티티를 분리해봤습니다. 피드백 주시면 도움 많이될 것 같습니다! 🙇‍♂️

## 3. 이후 작업

- [ ] 기존 동기방식의 추천/비추천 기능을 비동기 이벤트 구조로 변경
- [ ] 피드 추천 기능 설계 
