### PR TITLE
[추천 서버] 구성 설정 및 데이터 구조 정의 

### DIFF
--- a/devtribe-recommend-consumer/build.gradle.kts
+++ b/devtribe-recommend-consumer/build.gradle.kts
@@ -1,4 +1,5 @@
 dependencies {
     implementation(project(mapOf("path" to ":devtribe-recommend-core")))
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.cloud:spring-cloud-starter-stream-kafka")
 }

--- a/devtribe-recommend-consumer/docker/docker-compose-recommend.yml
+++ b/devtribe-recommend-consumer/docker/docker-compose-recommend.yml
@@ -1,0 +1,71 @@
+volumes:
+  esvol01:
+    driver: local
+  kibanavol:
+    driver: local
+
+networks:
+  devtribe-net:
+    external: true
+
+services:
+  es01:
+    container_name: recommend-elasticsearch
+    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}
+    volumes:
+      - esvol01:/usr/share/elasticsearch/data
+    ports:
+      - ${ES_PORT}:9200
+    environment:
+      - node.name=es-node
+      - cluster.name=${CLUSTER_NAME}
+      - discovery.type=single-node
+      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
+      - bootstrap.memory_lock=true
+      - xpack.security.enabled=false
+      - xpack.security.http.ssl.enabled=false
+      - xpack.security.transport.ssl.enabled=false
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9200/_cluster/health" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  kibana:
+    container_name: recommend-kibana
+    depends_on:
+      es01:
+        condition: service_healthy
+    image: docker.elastic.co/kibana/kibana:${STACK_VERSION}
+    labels:
+      co.elastic.logs/module: kibana
+    volumes:
+      - kibanavol:/usr/share/kibana/data
+    ports:
+      - ${KIBANA_PORT}:5601
+    environment:
+      - SERVERNAME=kibana
+      - ELASTICSEARCH_HOSTS=http://es01:9200
+      - ELASTICSEARCH_USERNAME=kibana_system
+      - ELASTICSEARCH_PASSWORD=${KIBANA_PASSWORD}
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -s -I http://localhost:5601 | grep -q 'HTTP/1.1 302 Found'",
+        ]
+      interval: 10s
+      timeout: 10s
+      retries: 120
+
+  redis:
+    image: redis:latest
+    container_name: recommend-redis
+    ports:
+      - ${REDIS_PORT}:6379
+
+

--- a/devtribe-recommend-consumer/src/main/java/com/devtribe/global/config/ElasticsearchConfig.java
+++ b/devtribe-recommend-consumer/src/main/java/com/devtribe/global/config/ElasticsearchConfig.java
@@ -1,0 +1,27 @@
+package com.devtribe.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+
+@Configuration
+public class ElasticsearchConfig extends ElasticsearchConfiguration {
+
+    @Value("${spring.elasticsearch.uris[0]}")
+    private String host;
+
+    @Value("${spring.elasticsearch.username}")
+    private String username;
+
+    @Value("${spring.elasticsearch.password}")
+    private String password;
+
+    @Override
+    public ClientConfiguration clientConfiguration() {
+        return ClientConfiguration.builder()
+            .connectedTo(host)
+            .withBasicAuth(username, password)
+            .build();
+    }
+}

--- a/devtribe-recommend-consumer/src/main/java/com/devtribe/global/config/RedisConfig.java
+++ b/devtribe-recommend-consumer/src/main/java/com/devtribe/global/config/RedisConfig.java
@@ -1,0 +1,22 @@
+package com.devtribe.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+}

--- a/devtribe-recommend-consumer/src/main/java/com/devtribe/global/config/RetryTemplateConfig.java
+++ b/devtribe-recommend-consumer/src/main/java/com/devtribe/global/config/RetryTemplateConfig.java
@@ -1,0 +1,18 @@
+package com.devtribe.global.config;
+
+import org.springframework.cloud.stream.annotation.StreamRetryTemplate;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.support.RetryTemplate;
+
+@Configuration
+public class RetryTemplateConfig {
+
+    @StreamRetryTemplate
+    public RetryTemplate streamRetryTemplate() {
+        return RetryTemplate.builder()
+            .maxAttempts(3)
+            .exponentialBackoff(1000, 2.0, 5000)
+            .build();
+    }
+
+}

--- a/devtribe-recommend-consumer/src/main/resources/application-event.yml
+++ b/devtribe-recommend-consumer/src/main/resources/application-event.yml
@@ -1,0 +1,29 @@
+spring:
+  cloud:
+    function:
+      definition: postClick;postEvent;postVote;
+    stream:
+      binder:
+        brokers: ${EVENT_BROKER_URL}
+      bindings:
+        postEvent-in-0:
+          destination: postEvent
+          content-type: application/json
+          group: recommend-consumer-post-event
+          consumer:
+            max-attempts: 3 # 최대 시도 횟수 = 첫 시도 + 재시도
+            back-off-initial-interval: 1000 # 첫 재시도 대기 시간
+            back-off-multiplier: 2.0 # 재시도 배수
+            back-off-max-interval: 5000 # 최대 재시도 시간
+        postClick-in-0:
+          destination: postClick
+          content-type: application/json
+          group: recommend-consumer-post-click
+          consumer:
+            max-attempts: 2
+        postVote-in-0:
+          destination: postVote
+          content-type: application/json
+          group: recommend-consumer-post-vote
+          consumer:
+            max-attempts: 2

--- a/devtribe-recommend-consumer/src/main/resources/application-local.yml
+++ b/devtribe-recommend-consumer/src/main/resources/application-local.yml
@@ -1,0 +1,10 @@
+spring:
+  elasticsearch:
+    uris:
+      - ${ES_URI_0}
+    username: ${ES_USERNAME}
+    password: ${ES_PASSWORD}
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}

--- a/devtribe-recommend-consumer/src/main/resources/application.yml
+++ b/devtribe-recommend-consumer/src/main/resources/application.yml
@@ -1,0 +1,7 @@
+spring:
+  application:
+    name: devtribe-recommend-consumer
+
+  profiles:
+    active: local
+    include: event

--- a/devtribe-recommend-core/build.gradle.kts
+++ b/devtribe-recommend-core/build.gradle.kts
@@ -1,3 +1,4 @@
 dependencies {
-
+    api("org.springframework.boot:spring-boot-starter-data-elasticsearch")
+    api("org.springframework.boot:spring-boot-starter-data-redis")
 }

--- a/devtribe-recommend-core/src/main/java/com/devtribe/domain/post/dao/PostClickLogRepository.java
+++ b/devtribe-recommend-core/src/main/java/com/devtribe/domain/post/dao/PostClickLogRepository.java
@@ -1,0 +1,8 @@
+package com.devtribe.domain.post.dao;
+
+import com.devtribe.domain.post.entity.PostClickLogDocument;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface PostClickLogRepository extends ElasticsearchRepository<PostClickLogDocument, Long> {
+
+}

--- a/devtribe-recommend-core/src/main/java/com/devtribe/domain/post/dao/PostRepository.java
+++ b/devtribe-recommend-core/src/main/java/com/devtribe/domain/post/dao/PostRepository.java
@@ -1,0 +1,8 @@
+package com.devtribe.domain.post.dao;
+
+import com.devtribe.domain.post.entity.PostDocument;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface PostRepository extends ElasticsearchRepository<PostDocument, Long> {
+
+}

--- a/devtribe-recommend-core/src/main/java/com/devtribe/domain/post/entity/PostClickLogDocument.java
+++ b/devtribe-recommend-core/src/main/java/com/devtribe/domain/post/entity/PostClickLogDocument.java
@@ -1,0 +1,55 @@
+package com.devtribe.domain.post.entity;
+
+import java.time.Instant;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+@Document(indexName = "post-click-logs")
+public class PostClickLogDocument {
+
+    @Id
+    private Long id;
+
+    @Field(type = FieldType.Long)
+    private Long postId;
+
+    @Field(type = FieldType.Long)
+    private Long userId;
+
+    @Field(type = FieldType.Text)
+    private String careerInterest;
+
+    @Field(type = FieldType.Text)
+    private String careerLevel;
+
+    @Field(type = FieldType.Date, format = {DateFormat.date_hour_minute_second_millis, DateFormat.epoch_millis})
+    private Instant timestamp;
+
+    public PostClickLogDocument(
+        Long postId,
+        Long userId,
+        String careerLevel,
+        String careerInterest
+    ) {
+        this.postId = postId;
+        this.userId = userId;
+        this.careerLevel = careerLevel;
+        this.careerInterest = careerInterest;
+        this.timestamp = Instant.now();
+    }
+
+    @Override
+    public String toString() {
+        return "PostClickLogDocument{" +
+            "id=" + id +
+            ", postId=" + postId +
+            ", userId=" + userId +
+            ", careerInterest='" + careerInterest + '\'' +
+            ", careerLevel='" + careerLevel + '\'' +
+            ", timestamp=" + timestamp +
+            '}';
+    }
+}

--- a/devtribe-recommend-core/src/main/java/com/devtribe/domain/post/entity/PostDocument.java
+++ b/devtribe-recommend-core/src/main/java/com/devtribe/domain/post/entity/PostDocument.java
@@ -1,0 +1,28 @@
+package com.devtribe.domain.post.entity;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+@Document(indexName = "posts")
+public class PostDocument {
+
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Long)
+    private Long postId;
+
+    @Field(type = FieldType.Keyword)
+    private List<String> tags;
+
+    @Field(type = FieldType.Date, format = {DateFormat.date_hour_minute_second_millis, DateFormat.epoch_millis})
+    private LocalDateTime createdAt;
+
+    @Field(type = FieldType.Date, format = {DateFormat.date_hour_minute_second_millis, DateFormat.epoch_millis})
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## 1. 연관 이슈 
- related: #47 

## 2. 작업 내용 

추천 서버는 피드 서버에서 발행하는 이벤트를 구독하여, 추천용 DB에 저장하는 역할을 합니다.
이를 위한 초기 작업으로, 추천 서버에 필요한 의존성과 도메인 클래스를 정의했습니다.

- [x] spring-cloud-stream, redis, elasticesearch 패키지 의존성 추가
  - 추후 배치 처리, 집계 및 키워드 검색, 필터링 연산에 있어 RDB의 성능 한계가 예상되어 elasticesearch를 추천 DB로 선택.
- [x] 사용자의 게시글 클릭 로그, 게시글 도큐먼트 구조 정의

## 3. 이후 작업
- [ ] 이벤트 처리 로직 및 저장 기능 구현 #48  