### PR TITLE
[추천 서버] 이벤트 처리 로직 및 저장 기능 구현

### DIFF
--- a/devtribe-recommend-consumer/src/main/java/com/devtribe/consumer/PostClickConsumer.java
+++ b/devtribe-recommend-consumer/src/main/java/com/devtribe/consumer/PostClickConsumer.java
@@ -1,0 +1,24 @@
+package com.devtribe.consumer;
+
+import com.devtribe.event.PostClickEvent;
+import com.devtribe.task.PostClickTask;
+import java.util.function.Consumer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class PostClickConsumer {
+
+    private final PostClickTask postClickTask;
+
+    public PostClickConsumer(PostClickTask postClickTask) {
+        this.postClickTask = postClickTask;
+    }
+
+    @Bean(name = "postClick")
+    public Consumer<PostClickEvent> postClick() {
+        return postClickTask::processEvent;
+    }
+}

--- a/devtribe-recommend-consumer/src/main/java/com/devtribe/consumer/PostEventConsumer.java
+++ b/devtribe-recommend-consumer/src/main/java/com/devtribe/consumer/PostEventConsumer.java
@@ -1,0 +1,25 @@
+package com.devtribe.consumer;
+
+import com.devtribe.event.PostEvent;
+import com.devtribe.task.PostEventTask;
+import java.util.function.Consumer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class PostEventConsumer {
+
+    private final PostEventTask postEventTask;
+
+    public PostEventConsumer(PostEventTask postEventTask) {
+        this.postEventTask = postEventTask;
+    }
+    
+    @Bean(name = "postEvent")
+    public Consumer<PostEvent> postEvent() {
+        return postEventTask::process;
+    }
+
+}

--- a/devtribe-recommend-consumer/src/main/java/com/devtribe/consumer/PostVoteConsumer.java
+++ b/devtribe-recommend-consumer/src/main/java/com/devtribe/consumer/PostVoteConsumer.java
@@ -1,0 +1,33 @@
+package com.devtribe.consumer;
+
+import com.devtribe.domain.vote.entity.VoteType;
+import com.devtribe.event.PostVoteEvent;
+import com.devtribe.task.PostUnvoteTask;
+import com.devtribe.task.PostVoteTask;
+import java.util.function.Consumer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PostVoteConsumer {
+
+    private final PostVoteTask postVoteTask;
+    private final PostUnvoteTask postUnvoteTask;
+
+    public PostVoteConsumer(PostVoteTask postVoteTask, PostUnvoteTask postUnvoteTask) {
+        this.postVoteTask = postVoteTask;
+        this.postUnvoteTask = postUnvoteTask;
+    }
+
+    @Bean(name = "postVote")
+    public Consumer<PostVoteEvent> postVote() {
+        return event -> {
+            if (event.voteType() != VoteType.UNVOTE) {
+                postVoteTask.processEvent(event);
+            } else {
+                postUnvoteTask.processEvent(event);
+            }
+        };
+    }
+
+}

--- a/devtribe-recommend-consumer/src/main/java/com/devtribe/event/PostClickEvent.java
+++ b/devtribe-recommend-consumer/src/main/java/com/devtribe/event/PostClickEvent.java
@@ -1,0 +1,10 @@
+package com.devtribe.event;
+
+public record PostClickEvent(
+    Long postId,
+    Long userId,
+    String careerInterest,
+    String careerLevel
+) {
+
+}

--- a/devtribe-recommend-consumer/src/main/java/com/devtribe/event/PostEvent.java
+++ b/devtribe-recommend-consumer/src/main/java/com/devtribe/event/PostEvent.java
@@ -1,0 +1,23 @@
+package com.devtribe.event;
+
+import com.devtribe.domain.post.entity.PostDocument;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PostEvent(
+    PostEventType eventType,
+    Long postId,
+    List<String> tags,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+) {
+
+    public PostDocument toPostDocument() {
+        return new PostDocument(
+            this.postId,
+            this.tags,
+            this.createdAt,
+            this.updatedAt
+        );
+    }
+}

--- a/devtribe-recommend-consumer/src/main/java/com/devtribe/event/PostEventType.java
+++ b/devtribe-recommend-consumer/src/main/java/com/devtribe/event/PostEventType.java
@@ -1,0 +1,7 @@
+package com.devtribe.event;
+
+public enum PostEventType {
+    CREATED,
+    UPDATED,
+    DELETED
+}

--- a/devtribe-recommend-consumer/src/main/java/com/devtribe/event/PostVoteEvent.java
+++ b/devtribe-recommend-consumer/src/main/java/com/devtribe/event/PostVoteEvent.java
@@ -1,0 +1,14 @@
+package com.devtribe.event;
+
+import com.devtribe.domain.vote.entity.VoteType;
+import java.time.LocalDateTime;
+
+public record PostVoteEvent(
+    VoteType voteType,
+    Long userId,
+    Long postId,
+    LocalDateTime occurredAt
+) {
+
+
+}

--- a/devtribe-recommend-consumer/src/main/java/com/devtribe/task/PostClickTask.java
+++ b/devtribe-recommend-consumer/src/main/java/com/devtribe/task/PostClickTask.java
@@ -1,0 +1,26 @@
+package com.devtribe.task;
+
+import com.devtribe.domain.post.dao.PostClickLogRepository;
+import com.devtribe.domain.post.entity.PostClickLogDocument;
+import com.devtribe.event.PostClickEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PostClickTask {
+
+    private final PostClickLogRepository postClickLogRepository;
+
+    public PostClickTask(PostClickLogRepository postClickLogRepository) {
+        this.postClickLogRepository = postClickLogRepository;
+    }
+
+    public void processEvent(PostClickEvent event) {
+        PostClickLogDocument postClickLogDocument = new PostClickLogDocument(
+            event.postId(),
+            event.userId(),
+            event.careerLevel(),
+            event.careerInterest()
+        );
+        postClickLogRepository.save(postClickLogDocument);
+    }
+}

--- a/devtribe-recommend-consumer/src/main/java/com/devtribe/task/PostEventTask.java
+++ b/devtribe-recommend-consumer/src/main/java/com/devtribe/task/PostEventTask.java
@@ -1,0 +1,36 @@
+package com.devtribe.task;
+
+import com.devtribe.domain.post.dao.PostRepository;
+import com.devtribe.domain.post.entity.PostDocument;
+import com.devtribe.event.PostEvent;
+import com.devtribe.event.PostEventType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PostEventTask {
+
+    private final PostRepository postRepository;
+
+    public PostEventTask(PostRepository postRepository) {
+        this.postRepository = postRepository;
+    }
+
+    public void process(PostEvent event) {
+        PostEventType eventType = event.eventType();
+
+        if (eventType == PostEventType.CREATED) {
+            postRepository.save(event.toPostDocument());
+        }
+
+        if (eventType == PostEventType.UPDATED) {
+            PostDocument postDocument = postRepository.findById(event.postId())
+                .orElseThrow(() -> new IllegalArgumentException("Post not found"));
+            postDocument.updateTags(event.tags(), event.updatedAt());
+            postRepository.save(postDocument);
+        }
+
+        if (eventType == PostEventType.DELETED) {
+            postRepository.delete(event.toPostDocument());
+        }
+    }
+}

--- a/devtribe-recommend-consumer/src/main/java/com/devtribe/task/PostUnvoteTask.java
+++ b/devtribe-recommend-consumer/src/main/java/com/devtribe/task/PostUnvoteTask.java
@@ -1,0 +1,22 @@
+package com.devtribe.task;
+
+import com.devtribe.domain.vote.dao.PostVoteRedisRepository;
+import com.devtribe.event.PostVoteEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PostUnvoteTask {
+
+    private final PostVoteRedisRepository postVoteRedisRepository;
+
+    public PostUnvoteTask(PostVoteRedisRepository postVoteRedisRepository) {
+        this.postVoteRedisRepository = postVoteRedisRepository;
+    }
+
+    public void processEvent(PostVoteEvent event) {
+        postVoteRedisRepository.unvote(
+            event.postId(),
+            event.userId()
+        );
+    }
+}

--- a/devtribe-recommend-consumer/src/main/java/com/devtribe/task/PostVoteTask.java
+++ b/devtribe-recommend-consumer/src/main/java/com/devtribe/task/PostVoteTask.java
@@ -1,0 +1,23 @@
+package com.devtribe.task;
+
+import com.devtribe.domain.vote.dao.PostVoteRedisRepository;
+import com.devtribe.event.PostVoteEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PostVoteTask {
+
+    private final PostVoteRedisRepository postVoteRedisRepository;
+
+    public PostVoteTask(PostVoteRedisRepository postVoteRedisRepository) {
+        this.postVoteRedisRepository = postVoteRedisRepository;
+    }
+
+    public void processEvent(PostVoteEvent event) {
+        postVoteRedisRepository.vote(
+            event.postId(),
+            event.userId(),
+            event.voteType()
+        );
+    }
+}

--- a/devtribe-recommend-core/src/main/java/com/devtribe/domain/global/config/elasticsearch/ElasticsearchConfig.java
+++ b/devtribe-recommend-core/src/main/java/com/devtribe/domain/global/config/elasticsearch/ElasticsearchConfig.java
@@ -1,4 +1,4 @@
-package com.devtribe.global.config;
+package com.devtribe.domain.global.config.elasticsearch;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;

--- a/devtribe-recommend-core/src/main/java/com/devtribe/domain/global/config/redis/LuaScriptConfig.java
+++ b/devtribe-recommend-core/src/main/java/com/devtribe/domain/global/config/redis/LuaScriptConfig.java
@@ -1,0 +1,38 @@
+package com.devtribe.domain.global.config.redis;
+
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.data.redis.core.script.RedisScript;
+
+@Configuration
+public class LuaScriptConfig {
+
+    private static final String LUA_SCRIPT_PATH = "scripts/";
+
+    private static final String POST_VOTE = "post_vote.lua";
+    private static final String POST_UNVOTE = "post_unvote.lua";
+    private static final String POST_VOTE_COUNT = "post_vote_count.lua";
+
+    @Bean
+    public RedisScript<List> postVoteScript() {
+        return loadScript(POST_VOTE);
+    }
+
+    @Bean
+    public RedisScript<List> postUnvoteScript() {
+        return loadScript(POST_UNVOTE);
+    }
+
+    @Bean
+    public RedisScript<List> postVoteCountScript() {
+        return loadScript(POST_VOTE_COUNT);
+    }
+
+    private RedisScript<List> loadScript(String fileName) {
+        Resource scriptResource = new ClassPathResource(LUA_SCRIPT_PATH + fileName);
+        return RedisScript.of(scriptResource, List.class);
+    }
+}

--- a/devtribe-recommend-core/src/main/java/com/devtribe/domain/global/config/redis/RedisConfig.java
+++ b/devtribe-recommend-core/src/main/java/com/devtribe/domain/global/config/redis/RedisConfig.java
@@ -1,4 +1,4 @@
-package com.devtribe.global.config;
+package com.devtribe.domain.global.config.redis;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/devtribe-recommend-core/src/main/java/com/devtribe/domain/post/entity/PostDocument.java
+++ b/devtribe-recommend-core/src/main/java/com/devtribe/domain/post/entity/PostDocument.java
@@ -12,8 +12,6 @@ import org.springframework.data.elasticsearch.annotations.FieldType;
 public class PostDocument {
 
     @Id
-    private String id;
-
     @Field(type = FieldType.Long)
     private Long postId;
 
@@ -25,4 +23,21 @@ public class PostDocument {
 
     @Field(type = FieldType.Date, format = {DateFormat.date_hour_minute_second_millis, DateFormat.epoch_millis})
     private LocalDateTime updatedAt;
+
+    public PostDocument(
+        Long postId,
+        List<String> tags,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+    ) {
+        this.postId = postId;
+        this.tags = tags;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public void updateTags(List<String> tags, LocalDateTime updatedAt) {
+        this.tags = tags;
+        this.updatedAt = updatedAt;
+    }
 }

--- a/devtribe-recommend-core/src/main/java/com/devtribe/domain/vote/dao/PostVoteRedisRepository.java
+++ b/devtribe-recommend-core/src/main/java/com/devtribe/domain/vote/dao/PostVoteRedisRepository.java
@@ -1,0 +1,51 @@
+package com.devtribe.domain.vote.dao;
+
+import com.devtribe.domain.vote.entity.VoteType;
+import java.util.List;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class PostVoteRedisRepository {
+
+    public static final String POST_VOTES_KEY = "post:%d:votes";
+    public static final String UPVOTE_COUNT_KEY = "post:upvoteCount";
+    public static final String DOWNVOTE_COUNT_KEY = "post:downvoteCount";
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisScript<List> postVoteScript;
+    private final RedisScript<List> postUnvoteScript;
+
+    public PostVoteRedisRepository(
+        RedisTemplate<String, String> redisTemplate,
+        RedisScript<List> postVoteScript,
+        RedisScript<List> postUnvoteScript
+    ) {
+        this.redisTemplate = redisTemplate;
+        this.postVoteScript = postVoteScript;
+        this.postUnvoteScript = postUnvoteScript;
+    }
+
+    private String getPostVotesKey(Long postId) {
+        return String.format(POST_VOTES_KEY, postId);
+    }
+
+    public void vote(Long postId, Long userId, VoteType voteType) {
+        redisTemplate.execute(
+            postVoteScript,
+            List.of(getPostVotesKey(postId), UPVOTE_COUNT_KEY, DOWNVOTE_COUNT_KEY),
+            postId.toString(),
+            userId.toString(),
+            voteType.toString()
+        );
+    }
+
+    public void unvote(Long postId, Long userId) {
+        redisTemplate.execute(
+            postUnvoteScript,
+            List.of(getPostVotesKey(postId), UPVOTE_COUNT_KEY, DOWNVOTE_COUNT_KEY),
+            postId.toString(), userId.toString()
+        );
+    }
+}

--- a/devtribe-recommend-core/src/main/java/com/devtribe/domain/vote/entity/VoteType.java
+++ b/devtribe-recommend-core/src/main/java/com/devtribe/domain/vote/entity/VoteType.java
@@ -1,0 +1,5 @@
+package com.devtribe.domain.vote.entity;
+
+public enum VoteType {
+    UPVOTE, DOWNVOTE, UNVOTE
+}

--- a/devtribe-recommend-core/src/main/resources/scripts/post_unvote.lua
+++ b/devtribe-recommend-core/src/main/resources/scripts/post_unvote.lua
@@ -1,0 +1,18 @@
+local setKey, upCountKey, downCountKey = KEYS[1], KEYS[2], KEYS[3]
+local postId, userId = ARGV[1], ARGV[2]
+
+local removedUp = redis.call("SREM", setKey, userId .. ":UPVOTE")
+if removedUp == 1 then
+    redis.call("ZINCRBY", upCountKey, -1, postId)
+end
+
+local removedDown = redis.call("SREM", setKey, userId .. ":DOWNVOTE")
+if removedDown == 1 then
+    redis.call("ZINCRBY", downCountKey, -1, postId)
+end
+
+-- postId의 추천 수/ 비추천수 조회
+local upScore = redis.call("ZSCORE", upCountKey, postId)
+local downScore = redis.call("ZSCORE", downCountKey, postId)
+
+return {upScore, downScore}

--- a/devtribe-recommend-core/src/main/resources/scripts/post_vote.lua
+++ b/devtribe-recommend-core/src/main/resources/scripts/post_vote.lua
@@ -1,0 +1,23 @@
+local setKey, upCountKey, downCountKey = KEYS[1], KEYS[2], KEYS[3]
+local postId, userId, voteType = ARGV[1], ARGV[2], ARGV[3]
+
+local addKey = userId..":"..voteType
+-- voteType == UPVOTE ? DOWNVOTE : UPVOTE
+local remKey = userId..":"..(voteType=="UPVOTE" and "DOWNVOTE" or "UPVOTE")
+
+-- voteType == UPVOTE ? upCountKey : downCountKey
+local countAdd = (voteType=="UPVOTE" and upCountKey or downCountKey)
+local countRem = (voteType=="UPVOTE" and downCountKey or upCountKey)
+
+if redis.call("SREM", setKey, remKey) == 1 then
+  redis.call("ZINCRBY", countRem, -1, postId)
+end
+if redis.call("SADD", setKey, addKey) == 1 then
+  redis.call("ZINCRBY", countAdd, 1, postId)
+end
+
+-- postId의 추천 수/ 비추천수 조회
+local upScore = redis.call("ZSCORE", upCountKey, postId)
+local downScore = redis.call("ZSCORE", downCountKey, postId)
+
+return {upScore, downScore}

--- a/devtribe-recommend-core/src/main/resources/scripts/post_vote_count.lua
+++ b/devtribe-recommend-core/src/main/resources/scripts/post_vote_count.lua
@@ -1,0 +1,8 @@
+local upCountKey, downCountKey = KEYS[1], KEYS[2]
+local postId = ARGV[1]
+
+-- postId의 추천 수/ 비추천수 조회
+local upScore = redis.call("ZSCORE", upCountKey, postId)
+local downScore = redis.call("ZSCORE", downCountKey, postId)
+
+return {upScore, downScore}


### PR DESCRIPTION
## 1. 연관 이슈 
- related: #48 

## 2. 작업 내용 

피드 서버에서 발행된 이벤트를 구독하고, 이벤트를 받아 DB에 저장하는 기능을 추가했습니다.

- [x] 유저들의 게시글 클릭 로그 이벤트 추천 DB에 저장
- [x] 유저들의 게시글 수정 이벤트 추천 DB에 저장
- [x] 유저들의 게시글 추천/비추천 이벤트 Redis 캐시에 저장

## 3. 이후 작업
- [ ] #49 
