### PR TITLE
[추천서버] 추천 통계 정보 배치 구현

### DIFF
--- a/devtribe-recommend-batch/build.gradle.kts
+++ b/devtribe-recommend-batch/build.gradle.kts
@@ -1,0 +1,8 @@
+dependencies {
+    implementation(project(mapOf("path" to ":devtribe-recommend-core")))
+    implementation("org.springframework.boot:spring-boot-starter-batch")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    testImplementation("org.springframework.batch:spring-batch-test")
+
+    runtimeOnly("com.mysql:mysql-connector-j")
+}

--- a/devtribe-recommend-batch/docker/docker-compose-batch.yml
+++ b/devtribe-recommend-batch/docker/docker-compose-batch.yml
@@ -1,0 +1,30 @@
+services:
+  db:
+    image: mysql:8.0.37
+    container_name: devtribe-recommend-batch-db
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+    ports:
+      - ${PORT}:3306
+    volumes:
+      - batch_data:/var/lib/mysql # 데이터 파일 외부 마운트
+      - batch_data:/var/log/mysql # 로그 파일 외부 마운트
+      - ./mysql_conf:/etc/mysql/conf.d # 설정 파일 외부 마운트
+      - ./init/exporter_user.sql:/docker-entrypoint-initdb.d/exporter_user.sql:ro
+    command:
+      - "mysqld"
+      - "--character-set-server=utf8mb4"
+      - "--collation-server=utf8mb4_unicode_ci"
+    restart: always
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping", "--host=localhost" ]
+      interval: 10s
+      retries: 5
+      start_period: 30s
+      timeout: 10s
+
+volumes:
+  batch_data: { }

--- a/devtribe-recommend-batch/src/main/java/com/devtribe/DevtribeRecommendBatchApplication.java
+++ b/devtribe-recommend-batch/src/main/java/com/devtribe/DevtribeRecommendBatchApplication.java
@@ -1,0 +1,16 @@
+package com.devtribe;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+
+@SpringBootApplication
+public class DevtribeRecommendBatchApplication {
+
+	public static void main(String[] args) {
+		ConfigurableApplicationContext context = SpringApplication.run(DevtribeRecommendBatchApplication.class, args);
+		int exitCode = SpringApplication.exit(context);
+		System.exit(exitCode);
+	}
+
+}

--- a/devtribe-recommend-batch/src/main/java/com/devtribe/job/ClickStatisticsJobConfig.java
+++ b/devtribe-recommend-batch/src/main/java/com/devtribe/job/ClickStatisticsJobConfig.java
@@ -1,0 +1,64 @@
+package com.devtribe.job;
+
+import com.devtribe.domain.post.entity.PostClickLogDocument;
+import com.devtribe.step.ClickLogWriter;
+import com.devtribe.step.ElasticsearchSearchAfterItemReader;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Slf4j
+@Configuration
+public class ClickStatisticsJobConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final ElasticsearchOperations elasticsearchOperations;
+    private final ClickLogWriter clickLogWriter;
+
+    public ClickStatisticsJobConfig(
+        JobRepository jobRepository,
+        PlatformTransactionManager transactionManager,
+        ElasticsearchOperations elasticsearchOperations,
+        ClickLogWriter clickLogWriter
+    ) {
+        this.jobRepository = jobRepository;
+        this.transactionManager = transactionManager;
+        this.elasticsearchOperations = elasticsearchOperations;
+        this.clickLogWriter = clickLogWriter;
+    }
+
+    @Bean
+    public Job clickStatisticsJob() {
+        return new JobBuilder("clickStatisticsJob", jobRepository)
+            .start(aggregateByCareerInterestAndLevel())
+            .build();
+    }
+
+    @Bean
+    public Step aggregateByCareerInterestAndLevel() {
+        return new StepBuilder("aggregateByCareerInterestAndLevel", jobRepository)
+            .<PostClickLogDocument, PostClickLogDocument>chunk(500, transactionManager)
+            .reader(postClickReader())
+            .writer(clickLogWriter)
+            .build();
+    }
+
+    @Bean
+    public ElasticsearchSearchAfterItemReader<PostClickLogDocument> postClickReader() {
+        return new ElasticsearchSearchAfterItemReader<>(
+            elasticsearchOperations,
+            "post-click-logs",
+            10,
+            PostClickLogDocument.class,
+            "timestamp"
+        );
+    }
+}

--- a/devtribe-recommend-batch/src/main/java/com/devtribe/step/ClickLogWriter.java
+++ b/devtribe-recommend-batch/src/main/java/com/devtribe/step/ClickLogWriter.java
@@ -1,0 +1,29 @@
+package com.devtribe.step;
+
+import com.devtribe.domain.post.entity.PostClickLogDocument;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ClickLogWriter implements ItemWriter<PostClickLogDocument> {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public ClickLogWriter(RedisTemplate<String, Object> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Override
+    public void write(Chunk<? extends PostClickLogDocument> items) {
+        for (PostClickLogDocument item : items) {
+            String careerInterest = item.getCareerInterest();
+            String careerLevel = item.getCareerLevel();
+            String key =
+                "careerInterest:" + careerInterest + ":careerLevel:" + careerLevel + ":ranking";
+
+            redisTemplate.opsForZSet().incrementScore(key, item.getPostId(), 1L);
+        }
+    }
+}

--- a/devtribe-recommend-batch/src/main/java/com/devtribe/step/ElasticsearchSearchAfterItemReader.java
+++ b/devtribe-recommend-batch/src/main/java/com/devtribe/step/ElasticsearchSearchAfterItemReader.java
@@ -1,0 +1,107 @@
+package com.devtribe.step;
+
+import co.elastic.clients.elasticsearch._types.SortOptions;
+import co.elastic.clients.elasticsearch._types.SortOptionsBuilders;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchAllQuery;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+
+/**
+ * Elasticsearch SearchAfter 방식의 데이터 Reader. 이전 페이지의 마지막 문서의 정렬 기준 값으로 데이터를 가져오는 방식.
+ *
+ * @param <T>
+ */
+public class ElasticsearchSearchAfterItemReader<T> implements ItemReader<T> {
+
+    private final ElasticsearchOperations elasticsearchOperations;
+    private final String indexName;
+    private final int batchSize;
+    private final Class<T> targetClass;
+    private final String sortField;
+
+    private List<T> currentItems = new ArrayList<>();
+    private boolean hasNext = true;
+    private List<Object> searchAfterValues = null;
+    private int currentIndex = 0;
+
+    public ElasticsearchSearchAfterItemReader(
+        ElasticsearchOperations elasticsearchOperations,
+        String indexName,
+        int batchSize, Class<T> targetClass,
+        String sortField
+    ) {
+        this.elasticsearchOperations = elasticsearchOperations;
+        this.indexName = indexName;
+        this.batchSize = batchSize;
+        this.targetClass = targetClass;
+        this.sortField = sortField;
+    }
+
+    @Override
+    public T read() {
+        if (currentIndex >= currentItems.size()) {
+            fetchNextBatch();
+        }
+
+        if (currentIndex < currentItems.size()){
+            T t = currentItems.get(currentIndex++);
+            return t;
+        }
+
+        return null;
+    }
+
+    private void fetchNextBatch() {
+        if (!hasNext) {
+            return;
+        }
+
+        NativeQueryBuilder queryBuilder = new NativeQueryBuilder()
+            .withQuery(MatchAllQuery.of(f -> f)._toQuery())
+            .withSort(getSortOptions())
+            .withPageable(PageRequest.of(0, batchSize));
+
+        if (searchAfterValues != null) {
+            queryBuilder.withSearchAfter(searchAfterValues);
+        }
+
+        NativeQuery query = queryBuilder.build();
+
+        SearchHits<T> searchHits = elasticsearchOperations.search(
+            query,
+            targetClass,
+            IndexCoordinates.of(indexName)
+        );
+
+        currentItems = searchHits.getSearchHits().stream()
+            .map(SearchHit::getContent)
+            .collect(Collectors.toList());
+        currentIndex = 0;
+
+        setSearchAfterValues(searchHits);
+    }
+
+    private void setSearchAfterValues(SearchHits<T> searchHits) {
+        if (searchHits.isEmpty()) {
+            hasNext = false;
+        } else {
+            SearchHit<T> lastHit = searchHits.getSearchHits().get(
+                searchHits.getSearchHits().size() - 1);
+            searchAfterValues = lastHit.getSortValues();
+        }
+    }
+
+    private SortOptions getSortOptions() {
+        return SortOptionsBuilders.field(field -> field.field(sortField).order(SortOrder.Desc));
+    }
+}

--- a/devtribe-recommend-batch/src/main/resources/application-batch.yml
+++ b/devtribe-recommend-batch/src/main/resources/application-batch.yml
@@ -1,0 +1,4 @@
+spring:
+  batch:
+    job:
+      name: clickStatisticsJob

--- a/devtribe-recommend-batch/src/main/resources/application-local.yml
+++ b/devtribe-recommend-batch/src/main/resources/application-local.yml
@@ -1,0 +1,21 @@
+spring:
+  elasticsearch:
+    uris:
+      - ${ES_URI_0}
+    username: ${ES_USERNAME}
+    password: ${ES_PASSWORD}
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${MYSQL_URL}
+    username: ${MYSQL_USERNAME}
+    password: ${MYSQL_PASSWORD}
+  batch:
+    jdbc:
+      initialize-schema: always
+
+server:
+  port: ${SERVER_PORT}

--- a/devtribe-recommend-batch/src/main/resources/application.yml
+++ b/devtribe-recommend-batch/src/main/resources/application.yml
@@ -1,0 +1,7 @@
+spring:
+  application:
+    name: devtribe-recommend-batch
+  profiles:
+    active: local
+    include: batch
+

--- a/devtribe-recommend-core/src/main/java/com/devtribe/domain/global/config/redis/RedisConfig.java
+++ b/devtribe-recommend-core/src/main/java/com/devtribe/domain/global/config/redis/RedisConfig.java
@@ -5,6 +5,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
@@ -18,5 +21,14 @@ public class RedisConfig {
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> objectRedisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
     }
 }

--- a/devtribe-recommend-core/src/main/java/com/devtribe/domain/post/entity/PostClickLogDocument.java
+++ b/devtribe-recommend-core/src/main/java/com/devtribe/domain/post/entity/PostClickLogDocument.java
@@ -1,17 +1,19 @@
 package com.devtribe.domain.post.entity;
 
 import java.time.Instant;
+import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.DateFormat;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 
+@Getter
 @Document(indexName = "post-click-logs")
 public class PostClickLogDocument {
 
     @Id
-    private Long id;
+    private String id;
 
     @Field(type = FieldType.Long)
     private Long postId;

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,4 +5,5 @@ include 'devtribe-feed-consumer'
 include 'devtribe-recommend-api'
 include 'devtribe-recommend-consumer'
 include 'devtribe-recommend-core'
+include 'devtribe-recommend-batch'
 


### PR DESCRIPTION
## 1. 연관 이슈 
- related: #49 

## 2. 작업 내용 

추천 서버 DB에 저장되어 있는 추천 피처 데이터를 직군별, 연차별 인기 조회 게시글 통계를 캐싱하도록 배치 모듈을 구현했습니다.
캐싱된 통계 정보는 추후 피드 추천 API 구현 시 사용될 예정입니다.

- [x] Spring Batch 모듈 생성 & 의존성 추가. 
- [x] 추천 서버 DB(ES) ItemReader 구현.
- [x] 직군별, 연차별 인기 조회 수 통계 가공 후 캐시에 저장.

> 안녕하세요 @f-lab-moony 멘토님 추천 DB의 이벤트 로그 통계 배치 구현한 내용 공유드립니다.
> 구현 방식이나 설정에서 피드백 주시면 도움 많이될 것 같습니다! 🙇‍♂️

## 3. 이후 작업

- [ ] 통계 정보를 활용하여 사용자에게 맞춤형 피드를 추천해주는 추천 API 구현

## 4. 고려해본 것들 & 고민되는 점
> 배치 사이즈에 대해서

현재 구현한 방식은 스프링 배치의 청크 단위 기반으로 처리하도록 구현을 해봤습니다. 이때 청크의 사이즈를 어떤 기준으로 설정해야하는지 감이 잡히지 않았었는데요. 청크 사이크도 별도의 성능테스트를 통해서 적절한 값을 찾아야할 것 같은데, 이럴때는 어떤 지표들을 봐야할까요..?
