### PR TITLE
[리팩토링] 엔티티 필드 재사용을 위한 공통 엔티티 정의

### DIFF
--- a/devtribe-feed-core/src/main/java/com/devtribe/domain/comment/entity/Comment.java
+++ b/devtribe-feed-core/src/main/java/com/devtribe/domain/comment/entity/Comment.java
@@ -1,26 +1,22 @@
 package com.devtribe.domain.comment.entity;
 
+import com.devtribe.global.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
 
 @Getter
 @Entity
 @Table(name = "comment")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Comment {
+public class Comment extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,22 +36,6 @@ public class Comment {
 
     @Column(name = "downvote_count", nullable = false)
     private Integer downvoteCount;
-
-    @CreatedDate
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
-    @CreatedBy
-    @Column(name = "created_by", updatable = false)
-    private Long createdBy;
-
-    @LastModifiedBy
-    @Column(name = "updated_by")
-    private Long updatedBy;
 
     @Builder
     public Comment(Long postId, Long userId, String content) {

--- a/devtribe-feed-core/src/main/java/com/devtribe/domain/post/entity/Post.java
+++ b/devtribe-feed-core/src/main/java/com/devtribe/domain/post/entity/Post.java
@@ -1,6 +1,7 @@
 package com.devtribe.domain.post.entity;
 
 import com.devtribe.domain.user.entity.User;
+import com.devtribe.global.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -10,15 +11,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
@@ -26,7 +22,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Table(name = "post")
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Post {
+public class Post extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -56,22 +52,6 @@ public class Post {
 
     @Column(name = "is_deleted", nullable = false)
     private Boolean isDeleted;
-
-    @CreatedDate
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
-    @CreatedBy
-    @Column(name = "created_by", updatable = false)
-    private Long createdBy;
-
-    @LastModifiedBy
-    @Column(name = "updated_by")
-    private Long updatedBy;
 
     @Builder
     public Post(String title, String content, Long userId,

--- a/devtribe-feed-core/src/main/java/com/devtribe/domain/post/entity/PostTag.java
+++ b/devtribe-feed-core/src/main/java/com/devtribe/domain/post/entity/PostTag.java
@@ -1,5 +1,6 @@
 package com.devtribe.domain.post.entity;
 
+import com.devtribe.global.model.ReadOnlyEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -7,12 +8,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
@@ -20,7 +18,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "post_tag")
-public class PostTag {
+public class PostTag extends ReadOnlyEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -30,14 +29,6 @@ public class PostTag {
 
     @Column(name = "tag_id", nullable = false)
     private Long tagId;
-
-    @CreatedDate
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
-
-    @CreatedBy
-    @Column(name = "created_by", updatable = false)
-    private Long createdBy;
 
     public PostTag(Long postId, Long tagId) {
         this.postId = postId;

--- a/devtribe-feed-core/src/main/java/com/devtribe/domain/tag/entity/Tag.java
+++ b/devtribe-feed-core/src/main/java/com/devtribe/domain/tag/entity/Tag.java
@@ -1,5 +1,6 @@
 package com.devtribe.domain.tag.entity;
 
+import com.devtribe.global.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -7,15 +8,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
@@ -23,7 +19,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "tag")
-public class Tag {
+public class Tag extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,22 +27,6 @@ public class Tag {
 
     @Column(name = "name", nullable = false)
     private String name;
-
-    @CreatedDate
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
-    @CreatedBy
-    @Column(name = "created_by", updatable = false)
-    private Long createdBy;
-
-    @LastModifiedBy
-    @Column(name = "updated_by")
-    private Long updatedBy;
 
     public Tag(String name) {
         this.name = name;

--- a/devtribe-feed-core/src/main/java/com/devtribe/domain/user/entity/User.java
+++ b/devtribe-feed-core/src/main/java/com/devtribe/domain/user/entity/User.java
@@ -1,26 +1,22 @@
 package com.devtribe.domain.user.entity;
 
+import com.devtribe.global.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "user")
-public class User {
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -52,22 +48,6 @@ public class User {
 
     @Column(name = "blog_url")
     private String blogUrl;
-
-    @CreatedDate
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
-    @CreatedBy
-    @Column(name = "created_by", updatable = false)
-    private Long createdBy;
-
-    @LastModifiedBy
-    @Column(name = "updated_by")
-    private Long updatedBy;
 
     @Builder
     public User(String email, String nickname, String password, String biography,

--- a/devtribe-feed-core/src/main/java/com/devtribe/domain/vote/entity/PostVoteCount.java
+++ b/devtribe-feed-core/src/main/java/com/devtribe/domain/vote/entity/PostVoteCount.java
@@ -1,35 +1,25 @@
 package com.devtribe.domain.vote.entity;
 
+import com.devtribe.global.model.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 
 @Getter
 @Entity
 @Table(name = "post_vote_count")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PostVoteCount {
+public class PostVoteCount extends BaseTimeEntity {
 
     @EmbeddedId
     private PostVoteCountId id;
 
     @Column(name = "vote_count", nullable = false)
     private Integer voteCount;
-
-    @CreatedDate
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
 
 }
 

--- a/devtribe-feed-core/src/main/java/com/devtribe/domain/vote/entity/PostVoteCountId.java
+++ b/devtribe-feed-core/src/main/java/com/devtribe/domain/vote/entity/PostVoteCountId.java
@@ -5,7 +5,9 @@ import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import java.io.Serializable;
+import lombok.Getter;
 
+@Getter
 @Embeddable
 public class PostVoteCountId implements Serializable {
 

--- a/devtribe-feed-core/src/main/java/com/devtribe/domain/vote/entity/PostVoteLog.java
+++ b/devtribe-feed-core/src/main/java/com/devtribe/domain/vote/entity/PostVoteLog.java
@@ -1,5 +1,6 @@
 package com.devtribe.domain.vote.entity;
 
+import com.devtribe.global.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -8,21 +9,16 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
 
 @Getter
 @Entity
 @Table(name = "post_vote_log")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PostVoteLog {
+public class PostVoteLog extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,22 +33,6 @@ public class PostVoteLog {
     @Enumerated(value = EnumType.STRING)
     @Column(name = "vote_type", nullable = false)
     private VoteType voteType;
-
-    @CreatedDate
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
-    @CreatedBy
-    @Column(name = "created_by", updatable = false)
-    private Long createdBy;
-
-    @LastModifiedBy
-    @Column(name = "updated_by")
-    private Long updatedBy;
 
     @Builder
     public PostVoteLog(Long postId, Long userId, VoteType voteType) {

--- a/devtribe-feed-core/src/main/java/com/devtribe/global/model/BaseEntity.java
+++ b/devtribe-feed-core/src/main/java/com/devtribe/global/model/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.devtribe.global.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity extends BaseTimeEntity {
+
+    @CreatedBy
+    @Column(name = "created_by", updatable = false)
+    private Long createdBy;
+
+    @LastModifiedBy
+    @Column(name = "updated_by")
+    private Long updatedBy;
+
+}

--- a/devtribe-feed-core/src/main/java/com/devtribe/global/model/BaseTimeEntity.java
+++ b/devtribe-feed-core/src/main/java/com/devtribe/global/model/BaseTimeEntity.java
@@ -1,0 +1,26 @@
+package com.devtribe.global.model;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+}

--- a/devtribe-feed-core/src/main/java/com/devtribe/global/model/ReadOnlyEntity.java
+++ b/devtribe-feed-core/src/main/java/com/devtribe/global/model/ReadOnlyEntity.java
@@ -1,0 +1,25 @@
+package com.devtribe.global.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class ReadOnlyEntity {
+
+    @CreatedBy
+    @Column(name = "created_by", updatable = false)
+    private Long createdBy;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+}


### PR DESCRIPTION
## 1. 연관 이슈 
- related: close #57 

## 2. 작업 내용 

여러 엔티티에서 중복적으로 선언되던 생성일/수정일 필드를 BaseTimeEntity로 추출하여 공통 처리했습니다.
Spring Data JPA의 Auditing 기능을 활용하여 자동으로 시간 정보가 저장되도록 구성했습니다.

- [x] BaseTimeEntity 추상 클래스 정의 (createdAt, updatedAt)
- [x] BaseEntity 추상 클래스 정의 (createdBy, updatedBy)
- [x] 수정자/일자 없는 ReadOnlyEntity 정의
- [x] 각 엔티티에 공통 클래스 상속 적용

## 3. 이후 작업

- 없음
